### PR TITLE
Removing navigation list headings in footer

### DIFF
--- a/web/app/themes/xrnl/footer.php
+++ b/web/app/themes/xrnl/footer.php
@@ -7,7 +7,6 @@
                 </div>
 
                 <div class="col-md-4 my-4">
-                    <h3 class="font-xr text-uppercase">Extinction Rebellion</h3>
                     <?php wp_nav_menu( [
                     'theme_location'  => 'footer-1',
                     'menu_class'      => 'list-unstyled',
@@ -17,7 +16,6 @@
                 </div>
 
                 <div class="col-md-4 my-4">
-                    <h3 class="font-xr text-uppercase"><?php _e('EVENTS') ?></h3>
                     <?php wp_nav_menu( [
                     'theme_location'  => 'footer-2',
                     'menu_class'      => 'list-unstyled',


### PR DESCRIPTION
This removes the headings above the two navigation lists in the page footer. The links are to be restructured into two lists with five items each, and the headings will no longer be appropriate.

Current footer: 

<img width="1168" alt="old_footer" src="https://user-images.githubusercontent.com/25393215/73736228-bb0ea680-4740-11ea-84b5-ee5684ec16cd.png">

New footer with the re-ordered navigation lists (which still needs to be done in WP admin once this is live):

<img width="1156" alt="new_footer" src="https://user-images.githubusercontent.com/25393215/73736463-16409900-4741-11ea-8aeb-23c571d14e07.png">



