### PR TITLE
Aligning the social buttons in the mobile navigation menu

### DIFF
--- a/web/app/themes/xrnl/header.php
+++ b/web/app/themes/xrnl/header.php
@@ -43,19 +43,19 @@
                         'menu_class'      => 'navbar-nav language-menu',
                         'walker'          => new WP_Bootstrap_Navwalker(),
                     ] ); ?>
-
-                    <ul class="list-unstyled d-flex my-3 my-xl-0 align-items-center">
-                        <li class="mx-3 mx-lg-2">
-                            <a href="https://www.facebook.com/ExtinctionRebellionNL/" target="_blank" class="facebook" aria-label="facebook"><i class="fab text-black fa-facebook-f"></i></a></li>
-                        <li class="mx-3 mx-lg-2">
-                            <a href="https://twitter.com/nlrebellion" class="twitter" target="_blank" aria-label="twitter"><i class="fab text-black fa-twitter"></i></a></li>
-                        <li class="mx-3 mx-lg-2">
-                            <a href="https://www.instagram.com/extinctionrebellionnl/?hl=nl" target="_blank" class="insta" aria-label="instagram"><i class="fab text-black fa-instagram"></i></a></li>
-                        <li class="mx-3 mx-lg-2">
-                            <a href="/donate" class="btn btn-black"><?php _e('donate'); ?></a>
-                        </li>
-                    </ul>
                 </div>
+
+                <ul class="list-unstyled d-flex my-3 my-xl-0 align-items-center">
+                    <li class="mx-3 mx-lg-2">
+                        <a href="https://www.facebook.com/ExtinctionRebellionNL/" target="_blank" class="facebook" aria-label="facebook"><i class="fab text-black fa-facebook-f"></i></a></li>
+                    <li class="mx-3 mx-lg-2">
+                        <a href="https://twitter.com/nlrebellion" class="twitter" target="_blank" aria-label="twitter"><i class="fab text-black fa-twitter"></i></a></li>
+                    <li class="mx-3 mx-lg-2">
+                        <a href="https://www.instagram.com/extinctionrebellionnl/?hl=nl" target="_blank" class="insta" aria-label="instagram"><i class="fab text-black fa-instagram"></i></a></li>
+                    <li class="mx-3 mx-lg-2">
+                        <a href="/donate" class="btn btn-black"><?php _e('donate'); ?></a>
+                    </li>
+                </ul>
             </div>
         </nav>
     </header>


### PR DESCRIPTION
This is a minor change to the appearance of the mobile (vertical) navigation menu.

The social & donate buttons appear somewhat misaligned with the rest of the mobile nav menu. This is because the `<ul>` with the buttons is nested inside the `<div>` of the language switcher. By taking the list out of the div, it becomes its own flex-item and flows underneath the switcher in vertical view. The desktop-width horizontal navbar stays unchanged.

Closes #44.

# Before:
<img width="551" alt="Before-tablet" src="https://user-images.githubusercontent.com/25393215/74320311-afdefa80-4d80-11ea-9157-08c1736ab22d.png">

# After: 
<img width="544" alt="After-tablet" src="https://user-images.githubusercontent.com/25393215/74320350-be2d1680-4d80-11ea-89a9-607078ce0661.png">

# Unchanged horizontal navbar:
<img width="1219" alt="Wide-unchanged" src="https://user-images.githubusercontent.com/25393215/74320370-c5542480-4d80-11ea-9bf3-41d92c035544.png">

