### PR TITLE
Join page restructuring

### DIFF
--- a/web/app/themes/xrnl/assets/sass/join.scss
+++ b/web/app/themes/xrnl/assets/sass/join.scss
@@ -2,7 +2,7 @@
 .join {
   font-size: 1.4rem;
   .join-cover-image {
-    min-height: 60vh;
+    // min-height: 60vh;
     background-size: cover !important;
   }
 

--- a/web/app/themes/xrnl/join.php
+++ b/web/app/themes/xrnl/join.php
@@ -30,7 +30,7 @@ $events = new WP_Query( $args );
 get_header(); ?>
 
 <div class="join">
-  <div class="bg-blue px-3 py-lg-5 pb-5 text-center text-white join-cover-image" style="background: linear-gradient(rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0.45)), url('<?php the_field('join_cover_image_url'); ?>') no-repeat;">
+  <div class="bg-blue text-center text-white join-cover-image" style="background: linear-gradient(rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0.45)), url('<?php the_field('join_cover_image_url'); ?>') no-repeat;">
     <div class="py-5">
       <h1 class="display-2 text-uppercase font-xr"><?php the_title(); ?></h1>
       <div class="container">
@@ -39,13 +39,6 @@ get_header(); ?>
         </div>
       </div>
     </div>
-
-    <div class="my-3">
-      <a class="btn btn-lg btn-blue" href="#join">
-        <?php _e('JOIN XR', 'theme-xrnl'); ?></a>
-    </div>
-
-    <a href="https://facebook.com/ExtinctionRebellionNL" target="_blank" class="text-white text-reset text-underline">Facebook</a> <?php _e('or', 'theme-xrnl') ?> <a class="text-white text-reset text-underline" href="https://meetup.com/Extinction-Rebellion-NL" target="_blank">Meetup</a>
   </div>
 
   <div class="my-sm-5 my-4">
@@ -59,13 +52,10 @@ get_header(); ?>
     </div>
   </div>
 
-  <div class="py-sm-5 py-4 text-white" style="background: linear-gradient(rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0.55)), url('<?php the_field('intro_meeting_cover'); ?>') no-repeat; min-height: 45vh;">
-    <div class="container">
-      <div class="row py-5 text-center">
-        <div class="col-12 col-lg-8 mx-auto">
-          <h1><?php the_field('intro_meeting_title'); ?></h1>
-          <?php the_field('intro_meeting_description'); ?>
-        </div>
+  <div class="container-fluid text-center py-sm-5 py-4 bg-pink">
+    <div class="row py-5">
+      <div class="col-12 col-sm-10 col-md-8 col-lg-6 col-xl-5 mx-auto mt-4">
+        <?php the_field('signup_form'); ?>
       </div>
     </div>
   </div>
@@ -133,19 +123,6 @@ get_header(); ?>
     <div class="mt-5"><?php the_field('local_map'); ?></div>
   </div>
 
-  <div class="container-fluid text-center py-sm-5 py-4 bg-pink">
-    <a name="join"></a>
-    <div class="row py-5">
-      <div class="col-12 col-lg-8 mx-auto">
-        <h1>
-          <?php _e('JOIN', 'theme-xrnl'); ?>
-        </h1>
-      </div>
-      <div class="col-12 col-sm-10 col-md-8 col-lg-6 col-xl-5 mx-auto mt-4">
-        <?php the_field('signup_form'); ?>
-      </div>
-    </div>
-  </div>
 
   <div class="container-fluid text-center bg-blue py-sm-5 py-4">
     <div class="row pt-5">


### PR DESCRIPTION
## Main change: Form repositioning
### What
The form to leave the email behind has been moved much higher on the join page.

Before it was all the way at the bottom. Now it is appears before events and local groups. Note that in this screenshot the action network form is not rendered because the plugin isn't working locally for me at the moment. 

#### Before
![Screenshot_2020-05-07 Ready to rebel · Extinction Rebellion Netherlands](https://user-images.githubusercontent.com/15846595/81308439-0f982980-9082-11ea-9df1-282d986d7346.jpg)

#### After

![Screenshot_2020-05-07 DOE MEE · Extinction Rebellion Netherlands(1)](https://user-images.githubusercontent.com/15846595/81308478-1a52be80-9082-11ea-8645-94407eabb601.png)

### Why
Getting people's contact details is a crucial aspect for integrating them into the movement. Once we have their email, we can invite them to events in their area, inform them of upcoming actions etc. By having the form higher up on the page we hope to get more people signing up.

This decision is supported by Moritz from the integration circle and Koen from the design circle. They support this decision because:

1. There are no local events at the moment.
2. Events are already widely advertised on the home page. 

## Other minor changes

* **remove join section title:** As you can see in the previous image, the big `join` title on top of the form is also removed. This title was unnecessary because the page title is already `join`. Moreover, by removing the title from the code, all text within that section is customisable from the WordPress panel. 
* **remove text in page cover:** The cover image used to have an unnecessary 'join' button that linked to the form and links to Facebook and Meetup. As a result, the cover is smaller and the user stays within that page, rather than being redirected somewhere else

#### before

![ ](https://user-images.githubusercontent.com/15846595/81309769-9699d180-9083-11ea-8d05-91b90a0d1b02.jpg)
#### After

![Screenshot_2020-05-07 DOE MEE · Extinction Rebellion Netherlands(1)](https://user-images.githubusercontent.com/15846595/81309785-9a2d5880-9083-11ea-91ad-156673b9a18b.jpg)

* **removed section on attending an event near you**: this section is not relevant in the upcoming months due to corona.

![Screenshot_2020-05-07 Ready to rebel · Extinction Rebellion Netherlands](https://user-images.githubusercontent.com/15846595/81309909-be893500-9083-11ea-8a91-fd508cd056bb.png)
