### PR TITLE
Change iframe src to https

### DIFF
--- a/web/app/themes/xrnl/resources.php
+++ b/web/app/themes/xrnl/resources.php
@@ -16,7 +16,7 @@ get_header(); ?>
 </style>
 
 <iframe id="xr-academy"
-        src="http://resources.extinctionrebellion.nl"
+        src="https://resources.extinctionrebellion.nl"
         scrolling="no"
         allowfullscreen
         width="100%"
@@ -29,9 +29,9 @@ get_header(); ?>
     jQuery("#xr-academy").attr("src", get_localized_url(window.location.pathname));
       function get_localized_url(path) {
         if (path.match("/en")) {
-          return "http://resources.extinctionrebellion.nl/en";
+          return "https://resources.extinctionrebellion.nl/en";
         } else {
-          return "http://resources.extinctionrebellion.nl/nl";
+          return "https://resources.extinctionrebellion.nl/nl";
         }
       }
   });


### PR DESCRIPTION
In the current version of the resources page, the `src` of the iframe uses `http`. The mix of https in the parent page and http in the iframe is getting blocked by browsers for security reasons (even though http requests are forwarded to https automatically).

Now that the resources library is on a new host with SSL certificate, we can just change the `src` to `https` and all should be fine.
