### PR TITLE
Adjust iframe height calculation method

### DIFF
--- a/web/app/themes/xrnl/resources.php
+++ b/web/app/themes/xrnl/resources.php
@@ -40,7 +40,7 @@ get_header(); ?>
       iFrameResize({
         log: false,
         checkOrigin: true,
-        heightCalculationMethod: 'taggedElement'
+        heightCalculationMethod: 'bodyScroll' 
       }, '#xr-academy'
       );
   });


### PR DESCRIPTION
The resource library now has a search function. In cases where there are many search results, the results list can extend beyond the page height, which requires the iframe height to expand accordingly.

That doesn't happen currently, so long results lists are getting cut off. We need a different method for calculating the height of the iframe. Fortunately it's already built into the [resizer utility](https://github.com/davidjbradshaw/iframe-resizer/blob/master/docs/parent_page/options.md), so we just need to change an option.