### PR TITLE
Fix translation issues 

### DIFF
--- a/web/app/themes/xrnl/archive-meetup_events.php
+++ b/web/app/themes/xrnl/archive-meetup_events.php
@@ -54,7 +54,7 @@ get_header(); ?>
 
   <?php if ($cities) { ?>
     <form class="form-inline mt-4 flex-nowrap" method="get">
-      <label class="my-1 mr-2" for="city">Location</label>
+      <label class="my-1 mr-2" for="city"><?php _e('Location') ?></label>
 			<input type="hidden" name="paged" value="1" />
       <select name="city" class="custom-select my-1" id="city">
         <option value=""><?php _e('All') ?></option>
@@ -136,8 +136,8 @@ get_header(); ?>
 					'current' => max(1, $paged),
 					'total' => $events->max_num_pages,
 					'type' => 'array',
-					'prev_text' => '&laquo; Previous',
-					'next_text' => 'Next &raquo;',
+					'prev_text' => '&laquo; ' . translate('Previous'),
+					'next_text' => translate('Next') . ' &raquo;',
 				));
 				?>
 				<?php if ( ! empty( $pagination ) ) : ?>
@@ -150,12 +150,11 @@ get_header(); ?>
 					</ul>
 				<?php endif ?>
 			</nav>
-			<?php _e('Check <a href="https://www.facebook.com/ExtinctionRebellionNL/events/" target="_blank">Facebook</a> or <a href="https://www.meetup.com/Extinction-Rebellion-NL/events/" target="_blank">Meetup</a> for latest events') ?>.
+			<?php _e('Check', 'theme-xrnl') ?> <a href="https://www.facebook.com/ExtinctionRebellionNL/events/" target="_blank">Facebook</a> <?php _e('or', 'theme-xrnl') ?> <a href="https://www.meetup.com/Extinction-Rebellion-NL/events/" target="_blank">Meetup</a> <?php _e('for the latest events', 'theme-xrnl') ?>.
 		<?php else :
-			_e('Looks like there are no events, try clearing the filter and make sure to check <a href="https://www.facebook.com/ExtinctionRebellionNL/events/" target="_blank">Facebook</a> or <a href="https://www.meetup.com/Extinction-Rebellion-NL/events/" target="_blank">Meetup</a>');
-		endif; ?>
+			_e('Looks like there are no events, try clearing the filter and make sure to check') ?> <a href="https://www.facebook.com/ExtinctionRebellionNL/events/" target="_blank">Facebook</a> <?php _e('or', 'theme-xrnl') ?> <a href="https://www.meetup.com/Extinction-Rebellion-NL/events/" target="_blank">Meetup</a>'.
+		<?php endif; ?>
 	</div>
 </div>
 
 <?php get_footer(); ?>
-

--- a/web/app/themes/xrnl/footer.php
+++ b/web/app/themes/xrnl/footer.php
@@ -35,7 +35,7 @@
                     ] ); ?>
 
                     <div class="donate donate--footer">
-                        <a href="/donate" class="btn btn-primary"><?php _e('donate'); ?></a>
+                        <a href="<?php echo get_locale() === 'en_US' ? '/en/donate' : '/donate' ?>" class="btn btn-primary"><?php _e('donate'); ?></a>
                     </div>
 
                     <br />


### PR DESCRIPTION
### `footer.php:`
The Donate button in the page footer currently always points to the NL version of the donation page.
This adjusts the `href` according to the current locale.

### `archive-meetup_events.php:`
Some strings on the Events page are not translatable currently.
This inserts `_e()` and `translate()` functions so that it can be fixed in the WP admin.

<img width="1317" alt="events_after_2" src="https://user-images.githubusercontent.com/25393215/84010580-24175c80-a975-11ea-8219-c58168464c99.png"><img width="1319" alt="events_after_1" src="https://user-images.githubusercontent.com/25393215/84010578-22e62f80-a975-11ea-9802-2ca26a6493b0.png">
