### PR TITLE
New join page template and CFs

### DIFF
--- a/web/app/themes/xrnl/acf-json/group_5ecc1fbe2efa9.json
+++ b/web/app/themes/xrnl/acf-json/group_5ecc1fbe2efa9.json
@@ -355,23 +355,6 @@
                     "new_lines": ""
                 },
                 {
-                    "key": "field_5eccf68f0983c",
-                    "label": "Cover image",
-                    "name": "cover_image",
-                    "type": "url",
-                    "instructions": "",
-                    "required": 0,
-                    "conditional_logic": 0,
-                    "wrapper": {
-                        "width": "",
-                        "class": "",
-                        "id": ""
-                    },
-                    "wpml_cf_preferences": 0,
-                    "default_value": "",
-                    "placeholder": ""
-                },
-                {
                     "key": "field_5eccf68f0983d",
                     "label": "Groups",
                     "name": "groups",
@@ -412,10 +395,10 @@
                             "maxlength": ""
                         },
                         {
-                            "key": "field_5ecd917786425",
-                            "label": "Group type",
-                            "name": "type",
-                            "type": "select",
+                            "key": "field_5eed048fec5b8",
+                            "label": "Button link",
+                            "name": "button_link",
+                            "type": "url",
                             "instructions": "",
                             "required": 0,
                             "conditional_logic": 0,
@@ -424,18 +407,9 @@
                                 "class": "",
                                 "id": ""
                             },
-                            "wpml_cf_preferences": 0,
-                            "choices": {
-                                "local": "Local groups",
-                                "community": "Community groups"
-                            },
-                            "default_value": [],
-                            "allow_null": 0,
-                            "multiple": 0,
-                            "ui": 0,
-                            "return_format": "value",
-                            "ajax": 0,
-                            "placeholder": ""
+                            "default_value": "",
+                            "placeholder": "",
+                            "wpml_cf_preferences": 0
                         }
                     ]
                 }
@@ -851,5 +825,5 @@
     "hide_on_screen": "",
     "active": 1,
     "description": "",
-    "modified": 1592507616
+    "modified": 1592593450
 }

--- a/web/app/themes/xrnl/acf-json/group_5ecc1fbe2efa9.json
+++ b/web/app/themes/xrnl/acf-json/group_5ecc1fbe2efa9.json
@@ -1,0 +1,855 @@
+{
+    "key": "group_5ecc1fbe2efa9",
+    "title": "Join page sections",
+    "fields": [
+        {
+            "key": "field_5ecc1fbe3e3b2",
+            "label": "Cover Image",
+            "name": "join_cover_image_url",
+            "type": "url",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "default_value": "",
+            "placeholder": ""
+        },
+        {
+            "key": "field_5ecc20c2ad272",
+            "label": "Signup section",
+            "name": "signup_section",
+            "type": "group",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "layout": "block",
+            "sub_fields": [
+                {
+                    "key": "field_5ecc21a647948",
+                    "label": "Enabled",
+                    "name": "enabled",
+                    "type": "true_false",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "message": "",
+                    "default_value": 1,
+                    "ui": 1,
+                    "ui_on_text": "",
+                    "ui_off_text": ""
+                },
+                {
+                    "key": "field_5ecc217947946",
+                    "label": "Heading",
+                    "name": "heading",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                },
+                {
+                    "key": "field_5ecc218347947",
+                    "label": "Content",
+                    "name": "content",
+                    "type": "wysiwyg",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "default_value": "",
+                    "tabs": "all",
+                    "toolbar": "full",
+                    "media_upload": 1,
+                    "delay": 0
+                }
+            ]
+        },
+        {
+            "key": "field_5eccf2b0cb336",
+            "label": "Actions section",
+            "name": "actions_section",
+            "type": "group",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "layout": "block",
+            "wpml_cf_preferences": 0,
+            "sub_fields": [
+                {
+                    "key": "field_5eccf312134bf",
+                    "label": "Enabled",
+                    "name": "enabled",
+                    "type": "true_false",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "message": "",
+                    "default_value": 0,
+                    "ui": 1,
+                    "ui_on_text": "",
+                    "ui_off_text": "",
+                    "wpml_cf_preferences": 0
+                },
+                {
+                    "key": "field_5eccf2e9134bd",
+                    "label": "Heading",
+                    "name": "heading",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                },
+                {
+                    "key": "field_5eccf2f6134be",
+                    "label": "Description",
+                    "name": "description",
+                    "type": "textarea",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": "",
+                    "maxlength": "",
+                    "rows": "",
+                    "new_lines": "",
+                    "wpml_cf_preferences": 0
+                },
+                {
+                    "key": "field_5eccf334134c0",
+                    "label": "Cover image",
+                    "name": "cover_image",
+                    "type": "url",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": "",
+                    "wpml_cf_preferences": 0
+                },
+                {
+                    "key": "field_5eccf3bdc81fe",
+                    "label": "Broadcasts",
+                    "name": "broadcasts",
+                    "type": "repeater",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "collapsed": "",
+                    "min": 0,
+                    "max": 0,
+                    "layout": "table",
+                    "button_label": "Add Broadcast",
+                    "sub_fields": [
+                        {
+                            "key": "field_5eccf445c8201",
+                            "label": "Label",
+                            "name": "label",
+                            "type": "text",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "wpml_cf_preferences": 0,
+                            "default_value": "",
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "",
+                            "maxlength": ""
+                        },
+                        {
+                            "key": "field_5eccf42fc8200",
+                            "label": "Link",
+                            "name": "link",
+                            "type": "url",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "default_value": "",
+                            "placeholder": "",
+                            "wpml_cf_preferences": 0
+                        },
+                        {
+                            "key": "field_5eccf3cbc81ff",
+                            "label": "Type",
+                            "name": "type",
+                            "type": "select",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "choices": {
+                                "signal": "Signal",
+                                "telegram": "Telegram",
+                                "whatsapp": "WhatsApp"
+                            },
+                            "default_value": [],
+                            "allow_null": 0,
+                            "multiple": 0,
+                            "ui": 0,
+                            "return_format": "value",
+                            "wpml_cf_preferences": 0,
+                            "ajax": 0,
+                            "placeholder": ""
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "key": "field_5eccf68f09838",
+            "label": "Groups section",
+            "name": "groups_section",
+            "type": "group",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "layout": "block",
+            "sub_fields": [
+                {
+                    "key": "field_5eccf68f09839",
+                    "label": "Enabled",
+                    "name": "enabled",
+                    "type": "true_false",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "message": "",
+                    "default_value": 0,
+                    "ui": 1,
+                    "ui_on_text": "",
+                    "ui_off_text": ""
+                },
+                {
+                    "key": "field_5eccf68f0983a",
+                    "label": "Heading",
+                    "name": "heading",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                },
+                {
+                    "key": "field_5eccf68f0983b",
+                    "label": "Description",
+                    "name": "description",
+                    "type": "textarea",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "default_value": "",
+                    "placeholder": "",
+                    "maxlength": "",
+                    "rows": "",
+                    "new_lines": ""
+                },
+                {
+                    "key": "field_5eccf68f0983c",
+                    "label": "Cover image",
+                    "name": "cover_image",
+                    "type": "url",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "default_value": "",
+                    "placeholder": ""
+                },
+                {
+                    "key": "field_5eccf68f0983d",
+                    "label": "Groups",
+                    "name": "groups",
+                    "type": "repeater",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "collapsed": "",
+                    "min": 0,
+                    "max": 0,
+                    "layout": "table",
+                    "button_label": "Add Group",
+                    "sub_fields": [
+                        {
+                            "key": "field_5eccf68f0983e",
+                            "label": "Button label",
+                            "name": "button_label",
+                            "type": "text",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "wpml_cf_preferences": 0,
+                            "default_value": "",
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "",
+                            "maxlength": ""
+                        },
+                        {
+                            "key": "field_5ecd917786425",
+                            "label": "Group type",
+                            "name": "type",
+                            "type": "select",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "wpml_cf_preferences": 0,
+                            "choices": {
+                                "local": "Local groups",
+                                "community": "Community groups"
+                            },
+                            "default_value": [],
+                            "allow_null": 0,
+                            "multiple": 0,
+                            "ui": 0,
+                            "return_format": "value",
+                            "ajax": 0,
+                            "placeholder": ""
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "key": "field_5eccf8309fac1",
+            "label": "Resources section",
+            "name": "resources_section",
+            "type": "group",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "layout": "block",
+            "sub_fields": [
+                {
+                    "key": "field_5eccf8309fac2",
+                    "label": "Enabled",
+                    "name": "enabled",
+                    "type": "true_false",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": "",
+                    "message": "",
+                    "default_value": 0,
+                    "ui": 1,
+                    "ui_on_text": "",
+                    "ui_off_text": ""
+                },
+                {
+                    "key": "field_5eccf8309fac3",
+                    "label": "Heading",
+                    "name": "heading",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": "",
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                },
+                {
+                    "key": "field_5eccf8309fac4",
+                    "label": "Description",
+                    "name": "description",
+                    "type": "textarea",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": "",
+                    "default_value": "",
+                    "placeholder": "",
+                    "maxlength": "",
+                    "rows": "",
+                    "new_lines": ""
+                },
+                {
+                    "key": "field_5eccf8309fac5",
+                    "label": "Button label",
+                    "name": "button_label",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": "",
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                }
+            ]
+        },
+        {
+            "key": "field_5eccf9229fac6",
+            "label": "Events section",
+            "name": "events_section",
+            "type": "group",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "layout": "block",
+            "sub_fields": [
+                {
+                    "key": "field_5eccf9229fac7",
+                    "label": "Enabled",
+                    "name": "enabled",
+                    "type": "true_false",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "message": "",
+                    "default_value": 0,
+                    "ui": 1,
+                    "ui_on_text": "",
+                    "ui_off_text": ""
+                },
+                {
+                    "key": "field_5eccf9229fac8",
+                    "label": "Heading",
+                    "name": "heading",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                },
+                {
+                    "key": "field_5eccf9229fac9",
+                    "label": "Description",
+                    "name": "description",
+                    "type": "textarea",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "default_value": "",
+                    "placeholder": "",
+                    "maxlength": "",
+                    "rows": "",
+                    "new_lines": ""
+                },
+                {
+                    "key": "field_5eccf93c9facb",
+                    "label": "Cover image",
+                    "name": "cover_image",
+                    "type": "url",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": "",
+                    "wpml_cf_preferences": 0
+                },
+                {
+                    "key": "field_5eccf9229faca",
+                    "label": "Button label",
+                    "name": "button_label",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                }
+            ]
+        },
+        {
+            "key": "field_5eccf9fd54b80",
+            "label": "Do more section",
+            "name": "do_more_section",
+            "type": "group",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "layout": "block",
+            "sub_fields": [
+                {
+                    "key": "field_5eccf9fd54b81",
+                    "label": "Enabled",
+                    "name": "enabled",
+                    "type": "true_false",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "message": "",
+                    "default_value": 0,
+                    "ui": 1,
+                    "ui_on_text": "",
+                    "ui_off_text": ""
+                },
+                {
+                    "key": "field_5eccf9fd54b82",
+                    "label": "Heading",
+                    "name": "heading",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                },
+                {
+                    "key": "field_5eccfa3454b86",
+                    "label": "Actions",
+                    "name": "actions",
+                    "type": "repeater",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "collapsed": "",
+                    "min": 0,
+                    "max": 0,
+                    "layout": "table",
+                    "button_label": "Add Action",
+                    "sub_fields": [
+                        {
+                            "key": "field_5ecd9b45b9528",
+                            "label": "Title",
+                            "name": "title",
+                            "type": "text",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "wpml_cf_preferences": 0,
+                            "default_value": "",
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "",
+                            "maxlength": ""
+                        },
+                        {
+                            "key": "field_5ecd9af3eb14d",
+                            "label": "Description",
+                            "name": "description",
+                            "type": "textarea",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "default_value": "",
+                            "placeholder": "",
+                            "maxlength": "",
+                            "rows": "",
+                            "new_lines": "",
+                            "wpml_cf_preferences": 0
+                        },
+                        {
+                            "key": "field_5eebb6cb3614d",
+                            "label": "Buttons",
+                            "name": "buttons",
+                            "type": "repeater",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "wpml_cf_preferences": 0,
+                            "collapsed": "",
+                            "min": 0,
+                            "max": 0,
+                            "layout": "table",
+                            "button_label": "Add Button",
+                            "sub_fields": [
+                                {
+                                    "key": "field_5eebb6e63614e",
+                                    "label": "Button label",
+                                    "name": "button_label",
+                                    "type": "text",
+                                    "instructions": "",
+                                    "required": 0,
+                                    "conditional_logic": 0,
+                                    "wrapper": {
+                                        "width": "",
+                                        "class": "",
+                                        "id": ""
+                                    },
+                                    "wpml_cf_preferences": 0,
+                                    "default_value": "",
+                                    "placeholder": "",
+                                    "prepend": "",
+                                    "append": "",
+                                    "maxlength": ""
+                                },
+                                {
+                                    "key": "field_5eebb7243614f",
+                                    "label": "Button link",
+                                    "name": "button_link",
+                                    "type": "url",
+                                    "instructions": "",
+                                    "required": 0,
+                                    "conditional_logic": 0,
+                                    "wrapper": {
+                                        "width": "",
+                                        "class": "",
+                                        "id": ""
+                                    },
+                                    "default_value": "",
+                                    "placeholder": "",
+                                    "wpml_cf_preferences": 0
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "post_template",
+                "operator": "==",
+                "value": "doe-mee.php"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": 1,
+    "description": "",
+    "modified": 1592507616
+}

--- a/web/app/themes/xrnl/doe-mee.php
+++ b/web/app/themes/xrnl/doe-mee.php
@@ -10,6 +10,10 @@ get_header(); ?>
   return (object) get_field($section_id);
 } ?>
 
+<?php function insertURL($page_id) {
+  echo get_permalink(icl_object_id($page_id, 'page', true));
+} ?>
+
 <div class="join">
   <div class="bg-blue text-center text-white join-cover-image py-5" style="background: linear-gradient(rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0.45)), url('<?php the_field('join_cover_image_url'); ?>') no-repeat;">
       <h1 class="display-2 text-uppercase font-xr"><?php the_title(); ?></h1>
@@ -26,7 +30,7 @@ get_header(); ?>
       <div class="row">
         <div class="col-12 col-sm-10 col-md-8 col-lg-6 col-xl-6 mx-auto">
           <h2><?php echo($section->heading); ?></h2>
-          <p><?php echo($section->content); ?></p>
+          <?php echo($section->content); ?>
         </div>
       </div>
     </section>
@@ -40,9 +44,11 @@ get_header(); ?>
           <h2><?php echo($section->heading); ?></h2>
           <p><?php echo($section->description); ?></p>
           <div class="join-action-btns">
-            <?php foreach ($section->broadcasts as $broadcast) : ?>
-              <a class="btn btn-pink my-2" href="<?php echo($broadcast['link']); ?>"><?php echo($broadcast['label']); ?></a>
-            <?php endforeach; ?>
+            <?php if (is_array($section->broadcasts)) : ?>
+              <?php foreach ($section->broadcasts as $broadcast) : ?>
+                <a class="btn btn-pink my-2" href="<?php echo($broadcast['link']); ?>"><?php echo($broadcast['label']); ?></a>
+              <?php endforeach; ?>
+            <?php endif; ?>
           </div>
         </div>
       </div>
@@ -57,9 +63,11 @@ get_header(); ?>
           <h2><?php echo($section->heading); ?></h2>
           <p><?php echo($section->description); ?></p>
           <div class="join-action-btns">
-            <?php foreach ($section->groups as $group) : ?>
-              <a class="btn btn-yellow my-2" href="/<?php echo($group['type']); ?>"><?php echo($group['button_label']); ?></a>
-            <?php endforeach; ?>
+            <?php if(is_array($section->groups)) : ?>
+              <?php foreach ($section->groups as $group) : ?>
+                <a class="btn btn-yellow my-2" href="<?php echo($group['button_link']); ?>"><?php echo($group['button_label']); ?></a>
+              <?php endforeach; ?>
+            <?php endif; ?>
           </div>
         </div>
       </div>
@@ -73,7 +81,9 @@ get_header(); ?>
         <div class="col-12 col-sm-10 col-md-8 col-lg-6 col-xl-6 mx-auto">
           <h2><?php echo($section->heading); ?></h2>
           <p><?php echo($section->description); ?></p>
-          <a class="btn btn-black" href="/resources"><?php echo($section->button_label); ?></a>
+          <?php if(!empty($section->button_label)) : ?>
+            <a class="btn btn-black" href="<?php insertURL(7221) ?>"><?php echo($section->button_label); ?></a>
+          <?php endif; ?>
         </div>
       </div>
     </section>
@@ -86,7 +96,9 @@ get_header(); ?>
         <div class="col-12 col-sm-10 col-md-8 col-lg-6 col-xl-6 mx-auto">
           <h2><?php echo($section->heading); ?></h2>
           <p><?php echo($section->description); ?></p>
-          <a class="btn btn-blue" href="/events"><?php echo($section->button_label); ?></a>
+          <?php if(!empty($section->button_label)) : ?>
+            <a class="btn btn-blue" href="<?php insertURL(548) ?>"><?php echo($section->button_label); ?></a>
+          <?php endif; ?>
         </div>
       </div>
     </section>
@@ -100,19 +112,21 @@ get_header(); ?>
           <h2><?php echo($section->heading); ?></h2>
           <p><?php echo($section->description); ?></p>
           <div class="row do-more-actions">
-            <?php foreach ($section->actions as $action) : ?>
-              <div class="col-12 col-sm-10 col-md-8 col-lg-6 col-xl-6 mx-auto mb-5">
-                <h3><?php echo($action['title']) ?></h3>
-                <p><?php echo($action['description']) ?></p>
-                <?php if(is_array($action['buttons'])) : ?>
-                  <?php foreach ($action['buttons'] as $button) : ?>
-                    <?php if ($button['button_label']): ?>
-                      <a class="btn btn-black mt-1" href="<?php echo($button['button_link']); ?>"><?php echo($button['button_label']); ?></a>
-                    <?php endif; ?>
-                  <?php endforeach; ?>
-                <?php endif; ?>
-              </div>
-            <?php endforeach; ?>
+            <?php if(is_array($section->actions)) : ?>
+              <?php foreach ($section->actions as $action) : ?>
+                <div class="col-12 col-sm-10 col-md-8 col-lg-6 col-xl-6 mx-auto mb-5">
+                  <h3><?php echo($action['title']) ?></h3>
+                  <p><?php echo($action['description']) ?></p>
+                  <?php if(is_array($action['buttons'])) : ?>
+                    <?php foreach ($action['buttons'] as $button) : ?>
+                      <?php if ($button['button_label']): ?>
+                        <a class="btn btn-black my-2 mx-2" href="<?php echo($button['button_link']); ?>"><?php echo($button['button_label']); ?></a>
+                      <?php endif; ?>
+                    <?php endforeach; ?>
+                  <?php endif; ?>
+                </div>
+              <?php endforeach; ?>
+            <?php endif; ?>
           </div>
         </div>
       </div>

--- a/web/app/themes/xrnl/doe-mee.php
+++ b/web/app/themes/xrnl/doe-mee.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Template name: Doe mee
+ */
+
+
+get_header(); ?>
+
+<?php function getSection($section_id) {
+  return (object) get_field($section_id);
+} ?>
+
+<div class="join">
+  <div class="bg-blue text-center text-white join-cover-image py-5" style="background: linear-gradient(rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0.45)), url('<?php the_field('join_cover_image_url'); ?>') no-repeat;">
+      <h1 class="display-2 text-uppercase font-xr"><?php the_title(); ?></h1>
+      <div class="container">
+        <div class="col-lg-8 mx-auto">
+          <?php the_content(); ?>
+        </div>
+      </div>
+  </div>
+
+  <?php $section = getSection('signup_section'); ?>
+  <?php if ($section->enabled) : ?>
+    <section class="join-section container-fluid bg-pink px-2">
+      <div class="row">
+        <div class="col-12 col-sm-10 col-md-8 col-lg-6 col-xl-6 mx-auto">
+          <h2><?php echo($section->heading); ?></h2>
+          <p><?php echo($section->content); ?></p>
+        </div>
+      </div>
+    </section>
+  <?php endif; ?>
+
+  <?php $section = getSection('actions_section'); ?>
+  <?php if ($section->enabled) : ?>
+    <section class="join-section bg-blue text-white join-cover-image px-2" style="background: linear-gradient(rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0.45)), url('<?php echo($section->cover_image); ?>') no-repeat;">
+      <div class="row">
+        <div class="col-12 col-sm-10 col-md-8 col-lg-6 col-xl-6 mx-auto">
+          <h2><?php echo($section->heading); ?></h2>
+          <p><?php echo($section->description); ?></p>
+          <div class="join-action-btns">
+            <?php foreach ($section->broadcasts as $broadcast) : ?>
+              <a class="btn btn-pink my-2" href="<?php echo($broadcast['link']); ?>"><?php echo($broadcast['label']); ?></a>
+            <?php endforeach; ?>
+          </div>
+        </div>
+      </div>
+    </section>
+  <?php endif; ?>
+
+  <?php $section = getSection('groups_section'); ?>
+  <?php if ($section->enabled) : ?>
+    <section class="join-section bg-white px-2">
+      <div class="row">
+        <div class="col-12 col-sm-10 col-md-8 col-lg-6 col-xl-6 mx-auto">
+          <h2><?php echo($section->heading); ?></h2>
+          <p><?php echo($section->description); ?></p>
+          <div class="join-action-btns">
+            <?php foreach ($section->groups as $group) : ?>
+              <a class="btn btn-yellow my-2" href="/<?php echo($group['type']); ?>"><?php echo($group['button_label']); ?></a>
+            <?php endforeach; ?>
+          </div>
+        </div>
+      </div>
+    </section>
+  <?php endif; ?>
+
+  <?php $section = getSection('resources_section'); ?>
+  <?php if ($section->enabled) : ?>
+    <section class="join-section container-fluid bg-yellow px-2">
+      <div class="row">
+        <div class="col-12 col-sm-10 col-md-8 col-lg-6 col-xl-6 mx-auto">
+          <h2><?php echo($section->heading); ?></h2>
+          <p><?php echo($section->description); ?></p>
+          <a class="btn btn-black" href="/resources"><?php echo($section->button_label); ?></a>
+        </div>
+      </div>
+    </section>
+  <?php endif; ?>
+
+  <?php $section = getSection('events_section'); ?>
+  <?php if ($section->enabled) : ?>
+    <section class="join-section bg-blue text-white join-cover-image px-2" style="background: linear-gradient(rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0.45)), url('<?php echo($section->cover_image); ?>') no-repeat;">
+      <div class="row">
+        <div class="col-12 col-sm-10 col-md-8 col-lg-6 col-xl-6 mx-auto">
+          <h2><?php echo($section->heading); ?></h2>
+          <p><?php echo($section->description); ?></p>
+          <a class="btn btn-blue" href="/events"><?php echo($section->button_label); ?></a>
+        </div>
+      </div>
+    </section>
+  <?php endif; ?>
+
+  <?php $section = getSection('do_more_section'); ?>
+  <?php if ($section->enabled) : ?>
+    <section class="join-section container-fluid bg-blue px-2">
+      <div class="row">
+        <div class="col-12 col-sm-10 col-md-9 col-lg-8 col-xl-8 mx-auto">
+          <h2><?php echo($section->heading); ?></h2>
+          <p><?php echo($section->description); ?></p>
+          <div class="row do-more-actions">
+            <?php foreach ($section->actions as $action) : ?>
+              <div class="col-12 col-sm-10 col-md-8 col-lg-6 col-xl-6 mx-auto mb-5">
+                <h3><?php echo($action['title']) ?></h3>
+                <p><?php echo($action['description']) ?></p>
+                <?php if(is_array($action['buttons'])) : ?>
+                  <?php foreach ($action['buttons'] as $button) : ?>
+                    <?php if ($button['button_label']): ?>
+                      <a class="btn btn-black mt-1" href="<?php echo($button['button_link']); ?>"><?php echo($button['button_label']); ?></a>
+                    <?php endif; ?>
+                  <?php endforeach; ?>
+                <?php endif; ?>
+              </div>
+            <?php endforeach; ?>
+          </div>
+        </div>
+      </div>
+    </section>
+  <?php endif; ?>
+</div>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
### New Join page layout
This PR implements a [new layout](https://organise.earth/xr-netherlands/pl/gjhwy6h84pbcidkkfwb7qejjto) for the Join page with a new template and custom field set. 

The main change from the previous version is that every section can be hidden from the admin panel with a switch:

<img width="865" alt="section_switch" src="https://user-images.githubusercontent.com/25393215/85069543-99c0cb00-b1b4-11ea-8dbe-278372c1fae9.png">

There are some new flexible elements in the groups, actions, and do-more sections.

<img width="339" alt="share_btns" src="https://user-images.githubusercontent.com/25393215/85069823-09cf5100-b1b5-11ea-9a3b-2d244b03fcaa.png">

<img width="839" alt="add_actions" src="https://user-images.githubusercontent.com/25393215/85069959-456a1b00-b1b5-11ea-8bf0-095c2162d725.png">

This template has a new name because I'm thinking that this will make it easier to update the page without breaking it. This way we can take our time with setting up the new version and when it's ready we just change the permalink. Please tell me if this is bad idea :)