### PR TITLE
Updates for new WPML version

### DIFF
--- a/web/app/themes/xrnl/doe-mee.php
+++ b/web/app/themes/xrnl/doe-mee.php
@@ -11,7 +11,7 @@ get_header(); ?>
 } ?>
 
 <?php function insertURL($page_id) {
-  echo get_permalink(icl_object_id($page_id, 'page', true));
+  echo get_permalink(apply_filters('wpml_object_id', $page_id, 'page', true));
 } ?>
 
 <div class="join">

--- a/web/app/themes/xrnl/header.php
+++ b/web/app/themes/xrnl/header.php
@@ -68,10 +68,10 @@
                         <a href="https://www.instagram.com/extinctionrebellionnl/?hl=nl" target="_blank" class="insta" aria-label="instagram"><i class="fab text-black fa-instagram"></i></a></li>
                     <li class="mx-3 mx-lg-2">
                         <?php
-                        $donatePage = icl_object_id(308,'page', true); // 308 is page ID
+                        $donatePage = apply_filters('wpml_object_id', 308, 'page', true); // 308 is page ID
                         $donatePageURL = get_permalink( $donatePage );
                         ?>
-                        <a href="<?php echo $donatePageURL ?>" class="btn btn-black"><?php _e('donate'); ?></a>
+                        <a href="<?php echo $donatePageURL ?>" class="btn btn-black"><?php _e('donate', 'theme-xrnl'); ?></a>
                     </li>
                 </ul>
             </div>

--- a/web/app/themes/xrnl/single-community_group.php
+++ b/web/app/themes/xrnl/single-community_group.php
@@ -6,7 +6,7 @@
 get_header(); ?>
 
 <?php
-$communityPage = $translated_page = icl_object_id(6832, 'page', true); // XRNL: 6832 NL, 6853 EN
+$communityPage = apply_filters('wpml_object_id', 6832, 'page', true); // XRNL: 6832 NL, 6853 EN
 $communityPageURL = get_permalink($communityPage);
 $dark_image_overlay = get_field('group_cover_image_darkened');
 $hero_text_color = $dark_image_overlay ? 'white' : 'black';

--- a/web/app/themes/xrnl/single-volunteer_vacancy.php
+++ b/web/app/themes/xrnl/single-volunteer_vacancy.php
@@ -5,12 +5,12 @@
 
 get_header(); ?>
 
-<?php $volunteerPageURL = get_permalink(icl_object_id(51, 'page', true)); ?>
+<?php $volunteerPageURL = get_permalink(apply_filters('wpml_object_id', 51, 'page', true)); ?>
 <article id="post-<?php the_ID(); ?>" ?>
-<div class="row p-2 pt-4 p-md-5 m-2 bg-navy text-white background-icon-container">  
+<div class="row p-2 pt-4 p-md-5 m-2 bg-navy text-white background-icon-container">
 <img src="/app/uploads/2019/04/XR-symbol.svg" class="background-icon">
     <div class="col-12 col-xl-8">
-<a href="<?php echo $volunteerPageURL ?>" class="btn btn-black mb-4"><i class="fas fa-arrow-left"></i> 
+<a href="<?php echo $volunteerPageURL ?>" class="btn btn-black mb-4"><i class="fas fa-arrow-left"></i>
 <?php _e('View all roles', 'theme-xrnl'); ?>
 </a>
 <header>
@@ -19,15 +19,15 @@ get_header(); ?>
 <?php $role = json_decode(get_the_content()); ?>
     <h4 class="xr-font text-white"><?php echo $role->workingGroup ?>, <?php echo $role->localGroup ?></h4>
     <h6>
-        <?php _e('Published on', 'theme-xrnl'); ?> 
+        <?php _e('Published on', 'theme-xrnl'); ?>
         <?php the_date(); ?></h6>
     <h5 class="role-section-header">
-        <?php _e('Responsibilities', 'theme-xrnl'); ?> 
+        <?php _e('Responsibilities', 'theme-xrnl'); ?>
     </h5>
     <p class="preserve-line-breaks"><?php echo $role->responsibilities ?></p>
     <?php if($role->description): ?>
     <h5 class="role-section-header">
-        <?php _e('Description', 'theme-xrnl'); ?> 
+        <?php _e('Description', 'theme-xrnl'); ?>
     </h5>
     <p class="preserve-line-breaks"><?php echo $role->description ?></p>
     <?php endif; ?>
@@ -71,8 +71,8 @@ get_header(); ?>
         </div>
         <?php endif; ?>
     </div>
-</div>        
 </div>
 </div>
-        </article> 
+</div>
+        </article>
 <?php get_footer(); ?>

--- a/web/app/themes/xrnl/volunteer_vacancy-archive.php
+++ b/web/app/themes/xrnl/volunteer_vacancy-archive.php
@@ -60,13 +60,13 @@ $vacancies = new WP_Query([
 ]);
 ?>
 
-<div class="d-flex flex-wrap m-1">        
-<?php 
+<div class="d-flex flex-wrap m-1">
+<?php
 	$n_vacancies_rendered = 0;
 
 	while($vacancies->have_posts()){
-	$vacancies->the_post(); 
-	$role = json_decode(get_the_content()); 
+	$vacancies->the_post();
+	$role = json_decode(get_the_content());
 	if (
 	  (
 		$param_working_group and ($role->workingGroup != $param_working_group)
@@ -77,7 +77,7 @@ $vacancies = new WP_Query([
 
 	$n_vacancies_rendered++;
 ?>
-    
+
 
 <div class="role-card d-flex flex-column col-12 col-sm-6 col-lg-4 col-xl-3 p-1">
   <div class="role-header"><h5 class="m-0 font-xr"><?php echo $role->workingGroup ?>, <?php echo $role->localGroup ?></h5>
@@ -91,26 +91,26 @@ $vacancies = new WP_Query([
 	<div class="d-flex justify-content-between align-items-end">
 	<span class="d-flex flex-column justify-content-center">
 	  <span class="flex-grow-0" style="line-height: 1rem; font-size: 1.25rem;">
-	  <?php echo $role->timeCommitment->min ?>&ndash;<?php echo $role->timeCommitment->max ?> 
+	  <?php echo $role->timeCommitment->min ?>&ndash;<?php echo $role->timeCommitment->max ?>
 	  </span>
 	  <span class="font-size: 0.625rem">
 	  <?php _e('hours / week', 'theme-xrnl'); ?>
 	  </span>
-	  
+
 	</span>
 	<a href="<?php the_permalink(); ?>" class="btn btn-black"><?php _e('Learn more', 'theme-xrnl'); ?></a>
 	</div>
   </div>
 </div>
 
-<?php 
+<?php
 
 } wp_reset_query();
 
 if($n_vacancies_rendered == 0) :
 ?>
 
-<?php $volunteerPageURL = get_permalink(icl_object_id(51, 'page', true)); ?>
+<?php $volunteerPageURL = get_permalink(apply_filters('wpml_object_id', 51, 'page', true)); ?>
 <div class="d-flex justify-content-center align-items-center bg-navy m-1 p-5 w-100">
 <span class="font-xr text-white">
 <?php _e('No results found.')?>
@@ -119,7 +119,7 @@ if($n_vacancies_rendered == 0) :
 </span>
 </div>
 
-<?php endif; ?>	
+<?php endif; ?>
 </div>
 
 


### PR DESCRIPTION
The `icl_object_id` function from the WPML plugin has been deprecated. This replaces it with the [new method](https://wpml.org/wpml-hook/wpml_object_id/) in the five page templates that use it. The new method already works in the version of WPML that we're currently running on the live site, so it shouldn't cause any issues (I've also tested it on a local instance).

By the way I'm not trying to be annoying with removing the tab characters; apparently my text editor does that automatically. Hope this is ok :)
