### PR TITLE
CSS link-decoration quick-fix

### DIFF
--- a/web/app/themes/xrnl/assets/sass/_variables.scss
+++ b/web/app/themes/xrnl/assets/sass/_variables.scss
@@ -24,7 +24,7 @@ $btn-focus-width: 0 !default;
 $btn-border-width: 0 !default;
 $btn-border-radius-lg: 0 !default;
 
-$link-decoration: underline !default;
+$link-decoration: none !default;
 $link-color: #000 !default;
 $link-hover-color: map-get($theme-colors, "green") !default;
 $brand-font: "FucXed", Montserrat, sans-serif !default;


### PR DESCRIPTION
After updating the Advanced Custom Fields plugin, all links were suddenly underlined (?!?).
This changes the default text-decoration back to `none`.

### After updating ACF
<img width="1294" alt="image" src="https://user-images.githubusercontent.com/25393215/87828631-a69d1100-c87d-11ea-8b3e-8e177ffc69f2.png">

### With this, everything should look like it was before

<img width="1299" alt="image" src="https://user-images.githubusercontent.com/25393215/87828711-caf8ed80-c87d-11ea-93fd-72de65daa572.png">
