### PR TITLE
Fix events filter

### DIFF
--- a/web/app/themes/xrnl/archive-meetup_events.php
+++ b/web/app/themes/xrnl/archive-meetup_events.php
@@ -4,7 +4,7 @@
  */
 
 // city query param
-$param_city = get_query_var('city');
+$param_city = stripslashes(get_query_var('city'));
 
 // city query
 $query_city = $param_city ? array(

--- a/web/app/themes/xrnl/archive-meetup_events.php
+++ b/web/app/themes/xrnl/archive-meetup_events.php
@@ -33,7 +33,6 @@ $args = array(
 	'orderby' => 'meta_value',
 	'meta_key' => 'event_start_date',
 	'order' => 'ASC',
-	's' => '-cancelled -afgelast',
 	'meta_query' => array(
 		array(
 			'key' => 'event_start_date', // Check the start date field

--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -204,6 +204,7 @@ function event_cities() {
         'posts_per_page' => 1e9,
         'post_type' => 'meetup_events',
         'fields' => 'ids',
+        's' => '-cancelled -afgelast',
         'meta_query' => array(
             array(
                 'key' => 'event_start_date', // Check the start date field
@@ -224,7 +225,7 @@ function event_cities() {
         if ($venue == 'Online'){
             $city = 'Online';
         } elseif ($city == ''){
-            $city = $venue;
+            continue;
         }
         if (array_key_exists($city, $cities)) {
             $cities[$city]++;

--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -204,7 +204,6 @@ function event_cities() {
         'posts_per_page' => 1e9,
         'post_type' => 'meetup_events',
         'fields' => 'ids',
-        's' => '-cancelled -afgelast',
         'meta_query' => array(
             array(
                 'key' => 'event_start_date', // Check the start date field


### PR DESCRIPTION
This PR fixes two bugs in the events city filter:
The filter currently does not work 's Hertogenbosch as wp inserts a backslash in front of the apostrophe - stripping the backslashes from the city parameter fixes this.

Also, the logic used in "event_cities" is right now inconsistent with the actual event filter - this can cause the number of events appearing the cities dropdown to differ from the number of events displayed - this is also fixed.

I also removed the "cancelled / afgelast" filters as there are not a lot of cancelled events anymore and that filter is not very specific and could filter out events that are not actually cancelled