### PR TITLE
Template updates

### DIFF
--- a/web/app/themes/xrnl/archive-meetup_events.php
+++ b/web/app/themes/xrnl/archive-meetup_events.php
@@ -207,9 +207,13 @@ get_header(); ?>
 					</ul>
 				<?php endif ?>
 			</nav>
-			<?php _e('Check', 'theme-xrnl') ?> <a href="https://www.facebook.com/ExtinctionRebellionNL/events/" target="_blank">Facebook</a> <?php _e('for the latest events', 'theme-xrnl') ?>.
-		<?php else :
-			_e('Looks like there are no events, try clearing the filter and make sure to check') ?> <a href="https://www.facebook.com/ExtinctionRebellionNL/events/" target="_blank">Facebook</a>.
+		<?php else : ?>
+			<div class="text-center mt-5 pt-5">
+				<p>
+					<?php _e('Looks like there are no events, try clearing the filters.', 'theme-xrnl'); ?>
+				</p>
+				<a class="btn btn-black" href="<?php the_permalink(apply_filters('wpml_object_id', 548, 'page', true)) ?>"><?php _e('Clear filters', 'theme-xrnl'); ?></a>
+			</div>
 		<?php endif; ?>
 	</div>
 </div>

--- a/web/app/themes/xrnl/archive-meetup_events.php
+++ b/web/app/themes/xrnl/archive-meetup_events.php
@@ -47,7 +47,7 @@ $args = array(
 );
 // push the taxonomy search if the category parameter is found:
 if ($param_category) {
-	// $query_category = 
+	// $query_category =
 	$args['tax_query'] = array(
 		array(
 			'taxonomy' => 'meetup_category',
@@ -207,9 +207,9 @@ get_header(); ?>
 					</ul>
 				<?php endif ?>
 			</nav>
-			<?php _e('Check', 'theme-xrnl') ?> <a href="https://www.facebook.com/ExtinctionRebellionNL/events/" target="_blank">Facebook</a> <?php _e('or', 'theme-xrnl') ?> <a href="https://www.meetup.com/Extinction-Rebellion-NL/events/" target="_blank">Meetup</a> <?php _e('for the latest events', 'theme-xrnl') ?>.
+			<?php _e('Check', 'theme-xrnl') ?> <a href="https://www.facebook.com/ExtinctionRebellionNL/events/" target="_blank">Facebook</a> <?php _e('for the latest events', 'theme-xrnl') ?>.
 		<?php else :
-			_e('Looks like there are no events, try clearing the filter and make sure to check') ?> <a href="https://www.facebook.com/ExtinctionRebellionNL/events/" target="_blank">Facebook</a> <?php _e('or', 'theme-xrnl') ?> <a href="https://www.meetup.com/Extinction-Rebellion-NL/events/" target="_blank">Meetup</a>.
+			_e('Looks like there are no events, try clearing the filter and make sure to check') ?> <a href="https://www.facebook.com/ExtinctionRebellionNL/events/" target="_blank">Facebook</a>.
 		<?php endif; ?>
 	</div>
 </div>

--- a/web/app/themes/xrnl/footer.php
+++ b/web/app/themes/xrnl/footer.php
@@ -3,7 +3,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-md-12">
-                    <p>Extinction Rebellion Nederland is een grassroots beweging geïnspireerd op <a href="https://rebellion.earth" target="_blank">Extinction Rebellion UK</a>.</p>
+                    <p>Extinction Rebellion Nederland is een grassroots beweging geïnspireerd op <a href="https://extinctionrebellion.uk" target="_blank">Extinction Rebellion UK</a>.</p>
                 </div>
 
                 <div class="col-md-4 my-4">

--- a/web/app/themes/xrnl/resources.php
+++ b/web/app/themes/xrnl/resources.php
@@ -8,6 +8,9 @@ get_header(); ?>
 <script type="text/javascript" src="/app/themes/xrnl/assets/js/iframeResizer.min.js">
 </script>
 
+
+
+
 <style type="text/css">
   iframe {
     border: none;
@@ -15,14 +18,16 @@ get_header(); ?>
   }
 </style>
 
-<iframe id="xr-academy"
-        src="https://resources.extinctionrebellion.nl"
-        scrolling="no"
-        allowfullscreen
-        width="100%"
-        frameBorder="0"
-        >
-</iframe>
+<div style="overflow:auto;-webkit-overflow-scrolling:touch">
+  <iframe id="xr-academy"
+          src="https://resources.extinctionrebellion.nl"
+          scrolling="no"
+          allowfullscreen
+          width="100%"
+          frameBorder="0"
+          >
+  </iframe>
+</div>
 
 <script>
   jQuery(document).ready(function(){
@@ -40,10 +45,12 @@ get_header(); ?>
       iFrameResize({
         log: false,
         checkOrigin: true,
-        heightCalculationMethod: 'bodyScroll' 
+        heightCalculationMethod: 'bodyScroll'
       }, '#xr-academy'
       );
+      this.contentWindow.postMessage({"in_iframe": true}, 'https://resources.extinctionrebellion.nl');
   });
+
 </script>
 
 <?php get_footer(); ?>


### PR DESCRIPTION
This implements one small change in the footer:
- Update the link to XR UK, as they've recently moved to a new domain.

...and two small changes on Events page:

- Remove the sentence below the search results that referred visitors to Facebook or Meetup.

- Don't refer people to FB and Meetup when there are no search results; instead show a "Clear filters" button which will reload the page without filters.

<img width="1208" alt="image" src="https://user-images.githubusercontent.com/25393215/92124006-8ad5d600-edfd-11ea-8d4d-ffb8c5f1805e.png">


And two small changes for the resources template:

- Wrap the library iframe in a `div` for better scrolling behaviour on iOS.
- Send a message to the resource library telling it that it's being loaded inside an iframe.

When the library gets the message it will hide its (yet to be deployed) navigation bar. 

Like this, we can show a navigation bar when visitors arrive at resources.extinctionrebellion.nl from a direct link (which happens, because resources and categories get shared by linking to them, also on our social media). Currently, visitors see no navigation at all when arriving via direct link, and there is no obvious way of getting to the main website.
