### PR TITLE
Overwrite CSS for the WhyDonate plugin

### DIFF
--- a/web/app/themes/xrnl/assets/sass/app.scss
+++ b/web/app/themes/xrnl/assets/sass/app.scss
@@ -17,3 +17,4 @@
 @import "roles";
 @import "community";
 @import "local";
+@import "whydonate";

--- a/web/app/themes/xrnl/assets/sass/whydonate.scss
+++ b/web/app/themes/xrnl/assets/sass/whydonate.scss
@@ -1,0 +1,93 @@
+.whydonate {
+  /* Progress bar and button */
+  .appearance-preview {
+    .appearance-preview-card-shortcode {
+      box-shadow: none !important;
+    }
+    .apreview-progress-bar {
+      .apreview-raised-bar {
+        background-color: $xr-primary !important;
+      }
+    }
+    .apreview-donate-btn-div {
+      button {
+        margin: 0.4rem auto;
+        font-family: $brand-font;
+        font-size: 1.4rem;
+      }
+    }
+  }
+
+  /* Form */
+  .preview-card {
+    box-shadow: none;
+    border: none;
+    .preview-header {
+      font-family: $brand-font;
+      background-color: $xr-primary !important;
+      label {
+        color: $xr-white !important;
+        font-size: 1.3rem;
+      }
+      .close {
+        text-shadow: none !important;
+        color: $xr-white;
+      }
+    }
+    .preview-period-intervals {
+      label {
+        font-size: 1.2rem !important;
+      }
+    }
+    .preview-intervals-divider {
+      height: 5px;
+      *[class^="preview-intervals-"] {
+        height: 5px;
+      }
+    }
+    .preview-select-amount-s {
+      .preview-select-amount-options {
+        *[class^="amount-boundary-box-"] {
+          border-radius: 0px;
+          border-color: $xr-primary !important;
+        }
+      }
+      .other-amount-div {
+        input {
+          padding-left: 1rem;
+        }
+      }
+    }
+    .preview-user-info-div {
+      input {
+        padding-left: 1rem;
+      }
+    }
+    .tip-box {
+      .custom-select {
+        min-width: 10em;
+        background: none;
+      }
+    }
+    .preview-user-donate-btn-div {
+      button {
+        font-family: $brand-font;
+        font-size: 1.4rem;
+      }
+      .checkbox-if-anonymous-s {
+        .checkbox-if-anonymous-s-div-label {
+          label {
+            margin-left: 0.5rem;
+          }
+        }
+      }
+    }
+  }
+  &.wd-center {
+    .appearance-preview {
+      .appearance-preview-card-shortcode {
+        margin: 0 auto;
+      }
+    }
+  }
+}

--- a/web/app/themes/xrnl/assets/sass/whydonate.scss
+++ b/web/app/themes/xrnl/assets/sass/whydonate.scss
@@ -11,6 +11,7 @@
     }
     .apreview-donate-btn-div {
       button {
+        background: $xr-black !important;
         margin: 0.4rem auto;
         font-family: $brand-font;
         font-size: 1.4rem;
@@ -71,6 +72,7 @@
     }
     .preview-user-donate-btn-div {
       button {
+        background: $xr-black !important;
         font-family: $brand-font;
         font-size: 1.4rem;
       }


### PR DESCRIPTION
This defines the `whydonate` class for overwriting some of the default styling of the WhyDonate donation button, progress bar, and donation form. See [this Trello card](https://trello.com/c/LouTL1SI/70-add-whydonatenl-plugin-to-website) for the request and some before/after screenshots.

The `wd-center` class can be used for centering the button/progress bar:
```html
<div class="whydonate wd-center">
  [whydonate id="weuzk"]
</div>
```
