### PR TITLE
Enable smooth scrolling

### DIFF
--- a/web/app/themes/xrnl/rwb.php
+++ b/web/app/themes/xrnl/rwb.php
@@ -168,4 +168,15 @@ get_header(); ?>
   <?php endif; ?>
 </div>
 
+<script type="text/javascript">
+  jQuery(document).ready(function() {
+    jQuery("a[href='#join']").click(function(e) {
+      jQuery([document.documentElement, document.body]).animate({
+          scrollTop: jQuery("a[name='join']").offset().top
+      }, 500);
+      e.preventDefault();
+    });
+  });
+</script>
+
 <?php get_footer(); ?>


### PR DESCRIPTION
Addressing this [this request](https://trello.com/c/4yjGyqhQ/172-ux-smooth-scrolling) to enable smooth scrolling on the RWB page when the 'Sign up' button is clicked.
