### PR TITLE
Text content on community page

### DIFF
--- a/web/app/themes/xrnl/community_group-archive.php
+++ b/web/app/themes/xrnl/community_group-archive.php
@@ -17,6 +17,7 @@ get_header(); ?>
 
 <div id="community" class="container py-5">
     <h1 class="mt-5"><?php the_title(); ?></h1>
+    <p><?php the_content(); ?></p>
 
     <div class="row">
       <?php while($groups->have_posts()):$groups->the_post(); ?>


### PR DESCRIPTION
This puts the text content of the community archive page into a paragraph above the cards.
See Trello card for the request [here](https://trello.com/c/j9FxpPHq/87-page-community-content).

#### Screenshot
![gemeenschap_archive_desktop](https://user-images.githubusercontent.com/25393215/93064550-ec0c6d80-f677-11ea-8bb5-50b78af87d0b.png)
