### PR TITLE
Adjust layout on why-rebel page

### DIFF
--- a/web/app/themes/xrnl/assets/sass/why-rebel.scss
+++ b/web/app/themes/xrnl/assets/sass/why-rebel.scss
@@ -2,6 +2,9 @@ $portrait-diameter: 175px;
 $portrait-diameter-md: 150px;
 
 .why-rebel {
+  .content {
+    max-width: 900px;
+  }
   .hero {
     color: $xr-white;
     padding: 16rem 0 4rem 0.7rem;
@@ -101,7 +104,6 @@ $portrait-diameter-md: 150px;
   align-items: center;
   flex-wrap: nowrap;
   flex-direction: row;
-  // justify-content: space-between;
   min-height: $portrait-diameter;
   @include media-breakpoint-down(md) {
     flex-direction: column-reverse;

--- a/web/app/themes/xrnl/assets/sass/why-rebel.scss
+++ b/web/app/themes/xrnl/assets/sass/why-rebel.scss
@@ -95,6 +95,9 @@ $portrait-diameter-md: 150px;
       border-top: none;
       margin-top: 0;
     }
+    &.bottom {
+      border-bottom: none;
+    }
   }
 }
 

--- a/web/app/themes/xrnl/why-rebel.php
+++ b/web/app/themes/xrnl/why-rebel.php
@@ -17,7 +17,7 @@ get_header(); ?>
   <section class="hero" style="background: url('<?php echo $section->image; ?>') no-repeat center center / cover;">
       <div class="container-fluid">
         <div class="row">
-          <div class="col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">
+          <div class="content col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">
             <p class="reading-time"><?php echo $section->reading_time ? $section->reading_time : '' ?></p>
             <h1 class="display-2 text-uppercase font-xr"><?php echo $section->title; ?></h1>
             <p><?php echo $section->content ?></p>
@@ -29,7 +29,7 @@ get_header(); ?>
   <?php $section = getSection('quote_1'); $picture = $section->picture; ?>
   <section id="quote-1" class="quote-section container-fluid">
     <div class="row">
-      <div class="col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">
+      <div class="content col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">
         <div class="quote-container top">
           <div class="quote-content">
             <div class="text-blocks">
@@ -48,7 +48,7 @@ get_header(); ?>
 
   <section id="the-problem" class="text-section container-fluid">
     <div class="row">
-      <div class="col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">
+      <div class="content col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">
         <?php the_field('problem_section'); ?>
       </div>
     </div>
@@ -57,7 +57,7 @@ get_header(); ?>
   <?php $section = getSection('quote_2'); $picture = $section->picture; ?>
   <section id="quote-2" class="quote-section container-fluid">
     <div class="row">
-      <div class="col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">
+      <div class="content col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">
         <div class="quote-container">
           <div class="quote-content quote-right">
             <div class="text-blocks">
@@ -76,7 +76,7 @@ get_header(); ?>
 
   <section id="change-is-possible" class="text-section container-fluid">
     <div class="row">
-      <div class="col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">
+      <div class="content col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">
         <?php the_field('change_section'); ?>
       </div>
     </div>
@@ -85,7 +85,7 @@ get_header(); ?>
   <?php $labels = getSection('demands'); ?>
   <section id="demands" class="container-fluid">
     <div class="row">
-      <div class="col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">
+      <div class="content col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">
         <div id="demands-btn">
           <span id="reveal-demands-btn" class="demands-toggle reveal-demands"><?php echo $labels->show_demands_text ?></span>
           <span id="hide-demands-btn" class="demands-toggle hide-demands" style="display: none;"><?php echo $labels->hide_demands_text ?></span>
@@ -100,7 +100,7 @@ get_header(); ?>
 
   <section id="why-rebel" class="text-section container-fluid">
     <div class="row">
-      <div class="col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">
+      <div class="content col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">
         <?php the_field('why_rebel_section'); ?>
       </div>
     </div>
@@ -109,7 +109,7 @@ get_header(); ?>
   <?php $section = getSection('ctas'); ?>
   <section id="calls-to-action" class="container-fluid">
     <div class="row">
-      <div class="col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">
+      <div class="content col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">
         <div class="ctas">
           <a class="cta btn btn-lg btn-green" href="<?php echo $section->button_cta['url'] ?>">
             <?php echo $section->button_cta['label'] ?>


### PR DESCRIPTION
This sets the maximum width for content on the Why Rebel page to 900px [as requested](https://trello.com/c/WFu2TMXq/202-page-why-rebel-max-900px).

Also adds an option to remove the bottom border on quote blocks, [see this card](https://trello.com/c/hZUuTXO9/204-page-about-us-add-quote).