### PR TITLE
Avoid naming collision for local group custom post type

### DIFF
--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -224,7 +224,7 @@ add_action('init', function(){
         'rewrite'               => $rewrite,
         'capability_type'       => 'page',
     );
-    register_post_type( 'local_group', $args );
+    register_post_type( 'xrnl_local_group', $args );
 
 });
 
@@ -410,7 +410,7 @@ add_filter( 'rest_authentication_errors', function( $result ) {
 /* options page for custom fields that reusable across pages and only accessible by admins.
  * see more at: https://www.advancedcustomfields.com/resources/options-page/
  *
- * */ 
+ * */
 
 
 if( function_exists('acf_add_options_page') ) {


### PR DESCRIPTION
The `local_group` [custom post type](https://github.com/xrnl/extinction-rebellion-nl/pull/75) is causing a naming conflict with the "Local group" roles filter on the volunteer page.
In order to avoid this conflict we can just change the key under which the post type is registered with WP.
Thanks @Mananasi for figuring out the cause of the problem!