### PR TITLE
Fixed buttons in header getting pushed to new line on some mobile devices

### DIFF
--- a/web/app/themes/xrnl/assets/sass/header.scss
+++ b/web/app/themes/xrnl/assets/sass/header.scss
@@ -18,6 +18,14 @@
     @include media-breakpoint-down(sm) {
       height: 55px;
     }
+
+    &.show-xxs {
+      // Make sure the logo doesn't push the buttons off the screen on some mobile devices:
+      max-width: 30vw;
+
+      // quick hack to force that logo to the left
+      margin: 0 -15px;
+    }
   }
 
   .nav-item {
@@ -69,9 +77,4 @@
   .navbar-expand-xl .show-xxs  {
     display: none;
   }
-}
-
-.show-xxs {
-  // quick hack to force that logo to the left
-  margin: 0 -15px;
 }


### PR DESCRIPTION
From [Force Dutch mobile menu to 1 line](https://trello.com/c/z9BE0NFP/228-force-dutch-mobile-menu-to-1-line)

I did have issues reproducing this issue. I tried my best with the Google Chrome mobile emulator feature in the developer tools. I made the xxs version of the header image take up maximum of about a third of the screen. This allows the donate and join buttons to move in further.