### PR TITLE
Improve custom post types

### DIFF
--- a/web/app/themes/xrnl/acf-json/group_5f1ad30f2103e.json
+++ b/web/app/themes/xrnl/acf-json/group_5f1ad30f2103e.json
@@ -620,8 +620,8 @@
                             "key": "field_5f478e018a629",
                             "label": "Picture",
                             "name": "picture_url",
-                            "type": "url",
-                            "instructions": "Full URL of the picture in the Wordpress media library.",
+                            "type": "image",
+                            "instructions": "Select a picture from the Wordpress media library.",
                             "required": 0,
                             "conditional_logic": 0,
                             "wrapper": {
@@ -629,8 +629,16 @@
                                 "class": "",
                                 "id": ""
                             },
-                            "default_value": "",
-                            "placeholder": "",
+                            "return_format": "url",
+                            "preview_size": "thumbnail",
+                            "library": "all",
+                            "min_width": "",
+                            "min_height": "",
+                            "min_size": "",
+                            "max_width": "",
+                            "max_height": "",
+                            "max_size": "",
+                            "mime_types": "",
                             "wpml_cf_preferences": 0
                         }
                     ]
@@ -1033,5 +1041,5 @@
     "hide_on_screen": "",
     "active": 1,
     "description": "",
-    "modified": 1604266203
+    "modified": 1604309162
 }

--- a/web/app/themes/xrnl/acf-json/group_5f1ad30f2103e.json
+++ b/web/app/themes/xrnl/acf-json/group_5f1ad30f2103e.json
@@ -235,11 +235,11 @@
             ]
         },
         {
-            "key": "field_5f21f81593393",
-            "label": "Logo",
-            "name": "logo",
-            "type": "url",
-            "instructions": "Full URL of the logo image in the Wordpress media library.\r\nE.g. \"https:\/\/extinctionrebellion.nl\/app\/uploads\/2019\/04\/XR-symbol.svg\"",
+            "key": "field_5f9f10703da60",
+            "label": "Appearance",
+            "name": "appearance",
+            "type": "group",
+            "instructions": "",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
@@ -247,9 +247,35 @@
                 "class": "",
                 "id": ""
             },
+            "layout": "block",
             "wpml_cf_preferences": 0,
-            "default_value": "",
-            "placeholder": ""
+            "sub_fields": [
+                {
+                    "key": "field_5f9f10bf3da61",
+                    "label": "Logo",
+                    "name": "logo",
+                    "type": "image",
+                    "instructions": "Select the logo image from the Wordpress media library.",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "return_format": "url",
+                    "preview_size": "thumbnail",
+                    "library": "all",
+                    "min_width": "",
+                    "min_height": "",
+                    "min_size": "",
+                    "max_width": "",
+                    "max_height": "",
+                    "max_size": "",
+                    "mime_types": ""
+                }
+            ]
         },
         {
             "key": "field_5f232e0479605",
@@ -331,8 +357,8 @@
                     "key": "field_5f478d570a024",
                     "label": "Picture",
                     "name": "picture_url",
-                    "type": "url",
-                    "instructions": "Full URL of the picture in the Wordpress media library.",
+                    "type": "image",
+                    "instructions": "Select a picture from the Wordpress media library.",
                     "required": 0,
                     "conditional_logic": 0,
                     "wrapper": {
@@ -340,9 +366,17 @@
                         "class": "",
                         "id": ""
                     },
-                    "wpml_cf_preferences": 0,
-                    "default_value": "",
-                    "placeholder": ""
+                    "return_format": "url",
+                    "preview_size": "thumbnail",
+                    "library": "all",
+                    "min_width": "",
+                    "min_height": "",
+                    "min_size": "",
+                    "max_width": "",
+                    "max_height": "",
+                    "max_size": "",
+                    "mime_types": "",
+                    "wpml_cf_preferences": 0
                 }
             ]
         },
@@ -950,14 +984,14 @@
                     "min": 0,
                     "max": 0,
                     "layout": "table",
-                    "button_label": "Add image",
+                    "button_label": "Add picture",
                     "sub_fields": [
                         {
                             "key": "field_5f233aa6aa7b5",
-                            "label": "Image URL",
+                            "label": "Picture",
                             "name": "image_url",
-                            "type": "url",
-                            "instructions": "",
+                            "type": "image",
+                            "instructions": "Select pictures from the Wordpress media library.",
                             "required": 0,
                             "conditional_logic": 0,
                             "wrapper": {
@@ -965,9 +999,17 @@
                                 "class": "",
                                 "id": ""
                             },
-                            "default_value": "",
-                            "placeholder": "",
-                            "wpml_cf_preferences": 0
+                            "wpml_cf_preferences": 0,
+                            "return_format": "url",
+                            "preview_size": "thumbnail",
+                            "library": "all",
+                            "min_width": "",
+                            "min_height": "",
+                            "min_size": "",
+                            "max_width": "",
+                            "max_height": "",
+                            "max_size": "",
+                            "mime_types": ""
                         }
                     ]
                 }
@@ -979,7 +1021,7 @@
             {
                 "param": "post_type",
                 "operator": "==",
-                "value": "local_group"
+                "value": "xrnl_local_group"
             }
         ]
     ],
@@ -991,5 +1033,5 @@
     "hide_on_screen": "",
     "active": 1,
     "description": "",
-    "modified": 1598525135
+    "modified": 1604266203
 }

--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -208,7 +208,7 @@ add_action('init', function(){
     $args = array(
         'label'                 => __( 'Local Group', 'text_domain' ),
         'labels'                => $labels,
-        'supports'              => array('title'),
+        'supports'              => array('title','author'),
         'hierarchical'          => false,
         'public'                => true,
         'show_ui'               => true,

--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -213,7 +213,7 @@ add_action('init', function(){
     $args = array(
         'label'                 => __( 'Local Group', 'text_domain' ),
         'labels'                => $labels,
-        'supports'              => array('title','author'),
+        'supports'              => array('title','author','revisions'),
         'hierarchical'          => false,
         'public'                => true,
         'show_ui'               => true,

--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -108,6 +108,11 @@ add_action('init', function(){
     );
     register_post_type( 'volunteer_vacancy', $args );
 
+    add_filter('user_can_richedit', function( $default ){
+      if( get_post_type() === 'volunteer_vacancy') return false;
+      return $default;
+    });
+
 });
 
 add_action('init', function(){

--- a/web/app/themes/xrnl/single-xrnl_local_group.php
+++ b/web/app/themes/xrnl/single-xrnl_local_group.php
@@ -24,7 +24,10 @@ get_header(); ?>
   }
 
   $bg_symbol = file_get_contents(get_template_directory_uri() . '/assets/images/bird.svg', false, getContext(WP_ENV));
-  $logo_url = get_field('logo') ?: get_template_directory_uri() . '/assets/images/XR-symbol.svg';
+  $appearance = get_field('appearance');
+  $logo_url = $appearance['logo'] ?: get_template_directory_uri() . '/assets/images/XR-symbol.svg';
+
+
 
   function getSection($section_id) {
     return (object) get_field($section_id);


### PR DESCRIPTION
Minor improvements for two custom post types:

1. Volunteer vacancy:
- Disable the visual editor to prevent WP from inserting `&amp;` character. Closes #100 
2. Local group:
- Add ability to associate an author with a group
- Add ability to select images from the media library (instead  of pasting in the URL)