### PR TITLE
Add ACF options sub pages

### DIFF
--- a/web/app/themes/xrnl/acf-json/group_5fa311a77eb3b.json
+++ b/web/app/themes/xrnl/acf-json/group_5fa311a77eb3b.json
@@ -1,0 +1,186 @@
+{
+    "key": "group_5fa311a77eb3b",
+    "title": "Demands",
+    "fields": [
+        {
+            "key": "field_5fa31249ed2fd",
+            "label": "Demands list",
+            "name": "xrnl_demands_list",
+            "type": "repeater",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "collapsed": "",
+            "min": 0,
+            "max": 0,
+            "layout": "table",
+            "button_label": "Add demand",
+            "sub_fields": [
+                {
+                    "key": "field_5fa3125aed2fe",
+                    "label": "Demand",
+                    "name": "demand",
+                    "type": "group",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "layout": "block",
+                    "sub_fields": [
+                        {
+                            "key": "field_5fa44583f6cd6",
+                            "label": "Bold text",
+                            "name": "bold_text",
+                            "type": "text",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "wpml_cf_preferences": 2,
+                            "default_value": "",
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "",
+                            "maxlength": ""
+                        },
+                        {
+                            "key": "field_5fa44593f6cd7",
+                            "label": "Regular text",
+                            "name": "regular_text",
+                            "type": "text",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "wpml_cf_preferences": 2,
+                            "default_value": "",
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "",
+                            "maxlength": ""
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "key": "field_5fa3f85802159",
+            "label": "Text above demands",
+            "name": "xrnl_demands_txt_above",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_5fa44251ca525",
+            "label": "Text below demands",
+            "name": "xrnl_demands_txt_below",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_5fa442870ed41",
+            "label": "Read more link target",
+            "name": "xrnl_demands_link_target",
+            "type": "page_link",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "post_type": [
+                "page"
+            ],
+            "taxonomy": "",
+            "allow_null": 1,
+            "allow_archives": 0,
+            "multiple": 0
+        },
+        {
+            "key": "field_5fa443d600a8b",
+            "label": "Read more link label",
+            "name": "xrnl_demands_link_label",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "options_page",
+                "operator": "==",
+                "value": "acf-options-editorial"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": 1,
+    "description": "",
+    "modified": 1604603323
+}

--- a/web/app/themes/xrnl/acf-json/nl/group_5f5f923355ed4.json
+++ b/web/app/themes/xrnl/acf-json/nl/group_5f5f923355ed4.json
@@ -1,0 +1,44 @@
+{
+    "key": "group_5f5f923355ed4",
+    "title": "API keys",
+    "fields": [
+        {
+            "key": "field_5f5f926247bb4",
+            "label": "Action Network API key",
+            "name": "actionnetwork_api_key",
+            "type": "text",
+            "instructions": "Someone with admin access to Action Network can obtain this API key.\r\n\r\nThis API key is necessary for getting the total number of petition signatures.",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 2,
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "options_page",
+                "operator": "==",
+                "value": "acf-options-admin"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": 1,
+    "description": "",
+    "modified": 1604523986
+}

--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -412,12 +412,39 @@ add_filter( 'rest_authentication_errors', function( $result ) {
     return $result;
 });
 
-/* options page for custom fields that reusable across pages and only accessible by admins.
+/*
+ * Options page for custom fields that reusable across pages.
+ * 'Admin Settings' is only accessible by admins,
+ * 'Editorial content' is accessible by editors also.
  * see more at: https://www.advancedcustomfields.com/resources/options-page/
- *
- * */
-
+ */
 
 if( function_exists('acf_add_options_page') ) {
-	acf_add_options_page();
+
+  $xrnl_settings = acf_add_options_page(array(
+  'page_title' => 'XRNL General Settings',
+  'menu_title' => 'XRNL Settings',
+  'menu_slug' => 'xrnl-general-settings',
+  'capability' => 'edit_others_pages',
+  'icon_url' => 'dashicons-pets',
+  'position' => '9',
+  'redirect' => true
+  ));
+
+  acf_add_options_sub_page(array(
+  'page_title' => 'Editorial Content',
+  'menu_title' => 'Editorial',
+  'parent_slug' => $xrnl_settings['menu_slug'],
+  'capability' => 'edit_others_pages',
+  'update_button' => 'Save content',
+  'updated_message' => 'Content saved'
+  ));
+
+  acf_add_options_sub_page(array(
+  'page_title' => 'Admin Settings',
+  'menu_title' => 'Admin',
+  'parent_slug' => $xrnl_settings['menu_slug'],
+  'capability' => 'manage_options'
+  ));
+
 }

--- a/web/app/themes/xrnl/template-parts/demands-list.php
+++ b/web/app/themes/xrnl/template-parts/demands-list.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * The template part for displaying the list of demands
+ */
+?>
+
+  <div class="demands-list">
+
+    <?php if (get_field('xrnl_demands_txt_above', 'option')) : ?>
+      <div class="mt-4">
+        <?php the_field('xrnl_demands_txt_above', 'option'); ?>
+      </div>
+    <?php endif; ?>
+
+    <?php if( have_rows('xrnl_demands_list', 'option') ): ?>
+      <ol class="pl-3 counter mt-3">
+        <?php while( have_rows('xrnl_demands_list', 'option') ): the_row(); ?>
+          <?php $demand = get_sub_field('demand'); ?>
+            <li class="pl-4">
+              <span class="text-green font-xr">
+                <?php echo $demand['bold_text']; ?>
+              </span>
+              <span>
+                <?php echo $demand['regular_text']; ?>
+              </span>
+            </li>
+        <?php endwhile; ?>
+      </ol>
+    <?php endif; ?>
+
+    <?php if (get_field('xrnl_demands_txt_below', 'option')) : ?>
+      <div class="mt-4">
+        <?php the_field('xrnl_demands_txt_below', 'option'); ?>
+      </div>
+    <?php endif; ?>
+
+    <?php if (get_field('xrnl_demands_link_target', 'option')) : ?>
+      <div class="pt-3 text-center">
+        <a href="<?php the_field('xrnl_demands_link_target', 'option'); ?>"><?php the_field('xrnl_demands_link_label', 'option'); ?></a>
+      </div>
+    <?php endif; ?>
+
+  </div>

--- a/web/app/themes/xrnl/why-rebel.php
+++ b/web/app/themes/xrnl/why-rebel.php
@@ -11,7 +11,7 @@ get_header(); ?>
   }
 ?>
 
-<div class="why-rebel">
+<main class="why-rebel">
 
   <?php $section = getSection('hero_section'); ?>
   <section class="hero" style="background: url('<?php echo $section->image; ?>') no-repeat center center / cover;">
@@ -91,8 +91,7 @@ get_header(); ?>
           <span id="hide-demands-btn" class="demands-toggle hide-demands" style="display: none;"><?php echo $labels->hide_demands_text ?></span>
         </div>
         <div id="demands-list" style="display: none;">
-          <?php $about_id = (apply_filters('wpml_current_language', NULL) === 'nl') ? 94 : 421; ?>
-          <?php the_field('demands', $about_id); // Grabbing the demands from the About us page ?>
+          <?php get_template_part('template-parts/demands-list'); ?>
         </div>
       </div>
     </div>
@@ -121,7 +120,8 @@ get_header(); ?>
       </div>
     </div>
   </section>
-</div>
+
+</main>
 
 <script type="text/javascript">
    jQuery(document).ready(function() {


### PR DESCRIPTION
Hey @SamLubbers & @jessejk89 this is meant as a sort of proposal. If you have time, I would really appreciate your thoughts :)

Because we've recently created an options page and are planning to add more items to it, I thought it would be useful to give it some structure. I also noticed that the API key for action network is currently visible (and editable) to all users, including authors, which is maybe not quite ideal because we're about to add many more users for the local groups.

So I thought it would be worth making subpages, which thankfully is really easy.

Here I've made a settings page "XRNL Settings" with two subpages:

- Admin: only visible to admins, can be used for things like that API key
- Editorial: accessible for editors, can be used for editorial content like the CTA from [Jesse's PR](https://github.com/xrnl/extinction-rebellion-nl/pull/88), or [the demands](https://trello.com/c/i3EcsEfN/197-refactor-make-demands-a-generic-custom-field-that-can-be-imported-in-different-pages).

I've coded a template for the demands, also to check if translations are working correctly (they are).
So like this, we can now insert the demands list into any post with something like 

```php
  get_template_part('template-parts/demands-list');
```
See the included why-rebel page as an example.

Do you think this might be a useful arrangement? Any comments welcome 🌻 

<img width="1361" alt="image" src="https://user-images.githubusercontent.com/25393215/98360880-e6edee00-202a-11eb-9da6-eb432c2c6a39.png">

<img width="1361" alt="image" src="https://user-images.githubusercontent.com/25393215/98360930-f9682780-202a-11eb-88e3-ad8fa4d6a666.png">

