### PR TITLE
Hide overflowing text in event info

### DIFF
--- a/web/app/themes/xrnl/assets/sass/events.scss
+++ b/web/app/themes/xrnl/assets/sass/events.scss
@@ -23,6 +23,12 @@
   }
 }
 
+.event_info {
+  line-height: 1.2rem;
+  height: 2.4rem !important;
+  overflow: hidden !important;
+}
+
 .event_date {
   background: #000 !important;
   color: #fff !important;
@@ -38,4 +44,3 @@
     margin-bottom: 6% !important;
   }
 }
-


### PR DESCRIPTION
This limits the event info to 2 lines and hides any overflowing text.

Closes #79. (well, partially ;) I think we can't actually prevent text on the images getting cut off, unless we want to start making sure that all images conform to a certain format)

### Before

<img width="509" alt="image" src="https://user-images.githubusercontent.com/25393215/99198386-8a13d580-2798-11eb-9d58-91cfffa62f00.png">


### After

<img width="503" alt="image" src="https://user-images.githubusercontent.com/25393215/99198397-a3b51d00-2798-11eb-802d-871dc6c697d0.png">
