### PR TITLE
Use ACF options

### DIFF
--- a/web/app/themes/xrnl/about.php
+++ b/web/app/themes/xrnl/about.php
@@ -33,7 +33,7 @@ get_header(); ?>
             <i class="fas fa-chevron-down"></i>
           </a>
           <div class="text-left collapse" id="demands">
-            <?php the_field('demands'); ?>
+            <?php get_template_part('template-parts/demands-list'); ?>
           </div>
         </div>
       </div>

--- a/web/app/themes/xrnl/acf-json/group_5f5f923355ed4.json
+++ b/web/app/themes/xrnl/acf-json/group_5f5f923355ed4.json
@@ -15,7 +15,7 @@
                 "class": "",
                 "id": ""
             },
-            "wpml_cf_preferences": 1,
+            "wpml_cf_preferences": 2,
             "default_value": "",
             "placeholder": "",
             "prepend": "",
@@ -28,7 +28,7 @@
             {
                 "param": "options_page",
                 "operator": "==",
-                "value": "acf-options"
+                "value": "acf-options-admin"
             }
         ]
     ],
@@ -38,7 +38,7 @@
     "label_placement": "top",
     "instruction_placement": "label",
     "hide_on_screen": "",
-    "active": 1,
+    "active": true,
     "description": "",
-    "modified": 1600099005
+    "modified": 1606129267
 }

--- a/web/app/themes/xrnl/petition.php
+++ b/web/app/themes/xrnl/petition.php
@@ -83,7 +83,7 @@ get_header(); ?>
                 </div>
 
                 <?= do_shortcode(get_field('actionnetwork_shortcode')) ?>
-                <? 
+                <?
                 /* #submission-cta-1 is shown after the form is submitted. */
                 /* #submission-cta-2 is shown after the user clicks on a button ins #submission-cta-1 */
                 ?>
@@ -138,7 +138,7 @@ get_header(); ?>
                     <i class="fas fa-chevron-down"></i>
                   </a>
                   <div class="text-left collapse" id="demands">
-                    <?php echo($section->demands); ?>
+                    <?php get_template_part('template-parts/demands-list'); ?>
                   </div>
                 </div>
               <?php endif; ?>
@@ -198,7 +198,7 @@ jQuery(document).ready(function() {
   });
 
   // show second call to action when user interacts with first call to action
-  
+
   jQuery("#form-donate").click(function(e) {
     showCTA2();
   })


### PR DESCRIPTION
This is only a quick follow-up to #102.

The ACF options page is now on the live site, and the demands are filled in.

This just changes the `petition` and `about` templates to use the new template-part for the demands, and tells the custom field for the AN key to show up on the ACF "admin" subpage.