### PR TITLE
Add ID to signup section on Join page

### DIFF
--- a/web/app/themes/xrnl/doe-mee.php
+++ b/web/app/themes/xrnl/doe-mee.php
@@ -14,6 +14,10 @@ get_header(); ?>
   echo get_permalink(apply_filters('wpml_object_id', $page_id, 'page', true));
 } ?>
 
+<?php function formatElementID($str) {
+    return strtolower(str_replace(' ', '-', $str));
+} ?>
+
 <div class="join">
   <div class="bg-blue text-center text-white join-cover-image py-5" style="background: linear-gradient(rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0.45)), url('<?php the_field('join_cover_image_url'); ?>') no-repeat;">
       <h1 class="display-2 text-uppercase font-xr"><?php the_title(); ?></h1>
@@ -26,7 +30,7 @@ get_header(); ?>
 
   <?php $section = getSection('signup_section'); ?>
   <?php if ($section->enabled) : ?>
-    <section class="join-section container-fluid bg-pink">
+    <section id="<?php echo formatElementID(__('Sign up','theme-xrnl')); ?>" class="join-section container-fluid bg-pink">
       <div class="row">
         <div class="col-12 col-sm-10 col-md-8 col-lg-6 col-xl-6 mx-auto">
           <h2><?php echo($section->heading); ?></h2>


### PR DESCRIPTION
Addresses [this request](https://trello.com/c/ZUAHNciJ/246-html-id-toevoegen-aan-doe-mee-pagina-om-zo-te-kunnen-linken-naar-nieuwsbrief-inschrijven) to add an element ID to the sign-up section on the Join page, so that the section can be linked to directly.

The ID is translatable, so that people can use either one of these:
https://extinctionrebellion.nl/en/join#sign-up
https://extinctionrebellion.nl/doe-mee#schrijf-je-in
