### PR TITLE
Local groups index page

### DIFF
--- a/web/app/themes/xrnl/acf-json/group_5fb6956308903.json
+++ b/web/app/themes/xrnl/acf-json/group_5fb6956308903.json
@@ -1,0 +1,134 @@
+{
+    "key": "group_5fb6956308903",
+    "title": "Local groups index",
+    "fields": [
+        {
+            "key": "field_5fb78d3bec6f2",
+            "label": "Hero image",
+            "name": "hero_image",
+            "type": "image",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "return_format": "url",
+            "preview_size": "thumbnail",
+            "library": "all",
+            "min_width": "",
+            "min_height": "",
+            "min_size": "",
+            "max_width": "",
+            "max_height": "",
+            "max_size": "",
+            "mime_types": "",
+            "wpml_cf_preferences": 0
+        },
+        {
+            "key": "field_5fb6bfade1304",
+            "label": "Hero text",
+            "name": "hero_text",
+            "type": "textarea",
+            "instructions": "This text is shown in the hero section",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "default_value": "",
+            "placeholder": "",
+            "maxlength": "",
+            "rows": "",
+            "new_lines": ""
+        },
+        {
+            "key": "field_5fb6deb678fed",
+            "label": "More info preview",
+            "name": "more_info_preview",
+            "type": "text",
+            "instructions": "Text for the more-info preview",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_5fb6deca78fee",
+            "label": "More info expanded",
+            "name": "more_info_expanded",
+            "type": "textarea",
+            "instructions": "Expanded info text",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "default_value": "",
+            "placeholder": "",
+            "maxlength": "",
+            "rows": 3,
+            "new_lines": ""
+        },
+        {
+            "key": "field_5fb6c93be52f3",
+            "label": "Show the map",
+            "name": "show_the_map",
+            "type": "radio",
+            "instructions": "Embed the map from XR Global",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "choices": {
+                "yes": "Yes",
+                "no": "No"
+            },
+            "allow_null": 0,
+            "other_choice": 0,
+            "default_value": "no",
+            "layout": "vertical",
+            "return_format": "value",
+            "save_other_choice": 0
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "page_template",
+                "operator": "==",
+                "value": "default"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "modified": 1606137588
+}

--- a/web/app/themes/xrnl/assets/sass/local.scss
+++ b/web/app/themes/xrnl/assets/sass/local.scss
@@ -1,3 +1,149 @@
+// Local groups archive
+
+.local-groups-hero {
+  background-image: linear-gradient(rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0.85)), var(--bg-image);
+  background-size: cover;
+  background-repeat: no-repeat;
+  padding: 3rem 0;
+  color: $xr-white;
+}
+
+.local-groups-info {
+
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+
+  .info-toggle {
+    align-self: flex-end;
+    @include media-breakpoint-down(xs) {
+      align-self: center;
+    }
+    background: $xr-light-blue;
+    display: inline-block;
+    padding: .1rem 1rem .1rem .5rem;
+    cursor: pointer;
+    &::after {
+      font-family: 'FontAwesome';
+      content: '\f068';
+      margin-left: .5rem;
+      font-size: .9rem;
+      display: inline-block;
+    }
+    &.expanded {
+      &::after {
+        content: '\f067';
+      }
+    }
+  }
+
+  .info-expand {
+    align-self: flex-end;
+    background: lighten($xr-light-blue, 10%);
+    padding: 1rem 2rem;
+    max-width: 30rem;
+    text-align: center;
+    a {
+      text-decoration: none !important;
+    }
+  }
+
+}
+
+
+.local-groups-index {
+
+  .index-container {
+    display: flex;
+    justify-content: center;
+    padding: 1.5rem 1.5rem 8rem 1.5rem;
+  }
+
+    .select-region {
+      padding: 2.2rem 3.8rem 0 0;
+
+      display: flex;
+      flex-direction: column;
+
+      @include media-breakpoint-down(xs) {
+        display: none;
+      }
+
+      position: -webkit-sticky;
+      position: sticky;
+      top: 1rem;
+      align-self: flex-start;
+
+      button {
+        display: none; // will be revealed if javascript is enabled
+
+        background: none;
+        border: none;
+        border-bottom: 4px solid $xr-white;
+        font-family: $brand-font;
+        font-size: 1.4rem;
+        white-space: nowrap;
+        outline: none;
+
+        padding: 0;
+        margin: .5rem;
+        align-self: flex-end;
+        transition: border 200ms ease-in;
+
+        &::before {
+          font-family: 'FontAwesome';
+          content: '\f0a4';
+          color: $xr-white;
+          text-decoration: none;
+          display: inline-block;
+          position: absolute;
+          transform: translateX(-2rem);
+          transition: color 200ms ease-in;
+        }
+        &.active {
+          border-color: $xr-warm-yellow;
+          &::before {
+            color: $xr-warm-yellow;
+          }
+        }
+      }
+
+    }
+
+    .groups-list {
+      flex-grow: 2;
+      padding: 0;
+
+      ul {
+        padding: 0;
+        margin: 0;
+      }
+
+      .initial-letter {
+        font-size: 3rem;
+        color: $xr-green;
+        break-after: avoid-column;
+        border-bottom: 1px solid $xr-light-gray; //$xr-green;
+        margin-top: 0.5rem;
+      }
+
+      li {
+        font-size: 1.5rem;
+        line-height: 2.5rem;
+        font-weight: bold;
+        list-style: none;
+        padding-left: 0.5rem;
+        margin-left: .5rem;
+        a {
+          text-decoration: none;
+        }
+      }
+    }
+}
+
+
+// Single local group page
+
 $hero-min-height: 250px;
 $logo-diameter: 130px;
 $logo-bg-diameter: 150px;

--- a/web/app/themes/xrnl/local_group-archive.php
+++ b/web/app/themes/xrnl/local_group-archive.php
@@ -1,0 +1,131 @@
+<?php
+/*
+* Template name: Local groups
+*/
+
+get_header(); ?>
+
+<?php
+  $groups = new WP_Query([
+    'order' => 'ASC',
+    'meta_key' => 'group_name',
+    'orderby' => 'meta_value',
+    'post_type' => 'xrnl_local_group',
+    'posts_per_page' => -1
+  ]);
+  $previous_letter = '';
+?>
+
+<div class="local-groups-hero" class="container-fluid" style="--bg-image: url('<?php the_field('hero_image'); ?>')">
+  <div class="row">
+    <div class="col-11 col-sm-10 col-lg-8 mx-auto">
+      <h1 class=""><?php the_title(); ?></h1>
+      <p class="top-text"><?php the_field('hero_text') ?></p>
+    </div>
+  </div>
+</div>
+
+<div class="local-groups-info">
+  <div class="info-toggle expanded"><?php the_field('more_info_preview') ?></div>
+  <div class="info-expand"> <?php the_field('more_info_expanded') ?></div>
+</div>
+
+<div class="local-groups-index row">
+  <div class="col-11 col-sm-10 col-lg-8 mx-auto">
+
+    <div class="index-container">
+      <div class="select-region">
+        <button type="button" name="all-regions" class="active" id="show-all-btn"><?php _e('All regions', 'theme-xrnl'); ?></button>
+        <button type="button" name="noord-west" class="region-select-btn">Noord-West</button>
+        <button type="button" name="noord-oost" class="region-select-btn">Noord-Oost</button>
+        <button type="button" name="midden" class="region-select-btn">Midden</button>
+        <button type="button" name="zuid-west" class="region-select-btn">Zuid-West</button>
+        <button type="button" name="zuid-oost" class="region-select-btn">Zuid-Oost</button>
+      </div>
+
+      <div class="groups-list">
+        <ul>
+        <?php while($groups->have_posts()):$groups->the_post(); ?>
+          <?php $group_name = get_field('group_name'); ?>
+          <?php $initial_letter = substr($group_name,0,1); ?>
+          <?php if (strcasecmp($initial_letter, $previous_letter) !== 0) : ?>
+            <div class="initial-letter">
+              <?php echo($initial_letter); ?>
+            </div>
+          <?php endif; ?>
+          <?php $previous_letter = $initial_letter; ?>
+          <li class="<?php echo strtolower(get_field('region')); ?> lg-name">
+            <a href="<?php the_permalink(); ?>"><?php echo $group_name; ?></a>
+          </li>
+        <?php endwhile; wp_reset_query(); ?>
+        </ul>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<?php if (get_field('show_the_map') === 'yes'): ?>
+  <div class="mt-5">
+    <iframe
+      title="XR Nederland <?php _e('map', 'theme-xrnl') ?>"
+      allowfullscreen width="100%"
+      height="600px"
+      src="https://rebellion.global/maps/nl-netherlands/branches"
+      >
+    </iframe>
+  </div>
+<?php endif; ?>
+
+<p><?php //the_content(); ?></p>
+
+<script type="text/javascript">
+  jQuery(document).ready(function(){
+
+    jQuery('.select-region > button').show();
+
+    // Show groups for one region
+    jQuery('.region-select-btn').click(function(e) {
+
+      // No doubleclicks please
+      if(e.originalEvent.detail > 1){
+        return;
+      }
+
+      jQuery('.lg-name').hide();
+      jQuery('.'+this.name).fadeIn(300);
+
+      // Only show index letters that have groups listed underneath
+      jQuery('.initial-letter')
+        .hide()
+        .filter(function() {
+          return jQuery(this).nextUntil('.initial-letter').not(':hidden').length
+          })
+        .fadeIn(300);
+
+      makeActive(this);
+    });
+
+    // Show all groups
+    jQuery("button[name='all-regions']").click(function() {
+      jQuery('.lg-name, .initial-letter').fadeIn(300);
+      makeActive(this);
+    });
+
+    // Info toggle
+    jQuery('.info-expand').hide();
+    jQuery('.info-toggle').click(function(e) {
+      jQuery('.info-toggle').toggleClass('expanded');
+      jQuery('.info-expand').slideToggle(300);
+      e.preventDefault();
+    });
+
+  });
+
+  function makeActive(btn) {
+      jQuery('.select-region > button').removeClass('active');
+      jQuery(btn).addClass('active');
+  }
+</script>
+
+<?php get_footer();


### PR DESCRIPTION
What's in this PR:
- A template for an index page that lists all local groups, with links to their individual pages
- Custom fields for a few settings and text snippets
- CSS

Happy to implement any feedback :)


#### Custom fields
<img width="878" alt="acf-index-page" src="https://user-images.githubusercontent.com/25393215/99967814-9f8c8f00-2d98-11eb-9736-22e4745fc2af.png">

#### Index page
![lg-index](https://user-images.githubusercontent.com/25393215/99967822-a2877f80-2d98-11eb-974a-d85b95de83a4.png)


