### PR TITLE
Change the slug for local groups

### DIFF
--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -205,7 +205,7 @@ add_action('init', function(){
         'filter_items_list'     => __( 'Filter items list', 'text_domain' ),
     );
     $rewrite = array(
-        'slug'                  => 'local',
+        'slug'                  => 'groep',
         'with_front'            => true,
         'pages'                 => true,
         'feeds'                 => true,
@@ -219,7 +219,7 @@ add_action('init', function(){
         'show_ui'               => true,
         'show_in_menu'          => true,
         'menu_position'         => 6,
-        'menu_icon'             => 'dashicons-groups',
+        'menu_icon'             => 'dashicons-location',
         'show_in_admin_bar'     => true,
         'show_in_nav_menus'     => true,
         'can_export'            => true,


### PR DESCRIPTION
This changes the slug for the local groups custom post type.

After this, the permalinks for LGs will be like

```
extinctionrebellion.nl/groep/maastricht
extinctionrebellion.nl/en/groep/maastricht
```
When we deploy this we need to remember to flush the permalinks, which can be done by going to Settings > permalinks & then clicking on "save changes" (without making any changes)

We can independently decide where to put the overview page. It could be
```
extinctionrebellion.nl/lokale-groepen 
extinctionrebellion.nl/en/local-groups
```
If we change the URL for the overview page, we should remember to add a redirect from `/local` and `/en/local` to the new overview pages.
