### PR TITLE
Remove the center picture on the intro talk page

### DIFF
--- a/web/app/themes/xrnl/acf-json/group_5fc7bc995cc35.json
+++ b/web/app/themes/xrnl/acf-json/group_5fc7bc995cc35.json
@@ -108,31 +108,6 @@
             "new_lines": ""
         },
         {
-            "key": "field_5fc7de799aaa5",
-            "label": "Center section picture",
-            "name": "screenshot_url",
-            "type": "image",
-            "instructions": "",
-            "required": 0,
-            "conditional_logic": 0,
-            "wrapper": {
-                "width": "",
-                "class": "",
-                "id": ""
-            },
-            "wpml_cf_preferences": 0,
-            "return_format": "url",
-            "preview_size": "thumbnail",
-            "library": "all",
-            "min_width": "",
-            "min_height": "",
-            "min_size": "",
-            "max_width": "",
-            "max_height": "",
-            "max_size": "",
-            "mime_types": ""
-        },
-        {
             "key": "field_5fc9fc36fbb7d",
             "label": "Day and time of the talk",
             "name": "date",
@@ -419,5 +394,5 @@
     "hide_on_screen": "",
     "active": true,
     "description": "",
-    "modified": 1607074461
+    "modified": 1607546093
 }

--- a/web/app/themes/xrnl/intro-talk.php
+++ b/web/app/themes/xrnl/intro-talk.php
@@ -37,11 +37,9 @@ get_header(); ?>
       </span>
     </div>
     <p class="col-10 col-md-8 col-lg-7 mx-auto text-center"><?php the_field('center_section_top_text') ?></p>
-    <div class="col-12 col-sm-10 col-md-10 col-lg-9 py-5 mx-auto row" style="min-height: 30rem; background: url('<?php the_field('screenshot_url') ?>') no-repeat center center/cover;">
-      <div class="col-12 align-self-end text-center">
-        <?php $view_btn = get_field('view_button'); ?>
-        <a href="<?php echo $view_btn['view_button_link']; ?>" class="btn btn-lg btn-yellow"><?php echo $view_btn['view_button_label']; ?></a>
-      </div>
+    <div class="col-12 text-center mt-2 mb-5">
+      <?php $view_btn = get_field('view_button'); ?>
+      <a href="<?php echo $view_btn['view_button_link']; ?>" class="btn btn-lg btn-yellow"><?php echo $view_btn['view_button_label']; ?></a>
     </div>
     <p class="col-11 col-md-9 col-lg-8 mx-auto mt-3 text-center"><?php the_field('center_section_bottom_text') ?></p>
   </div>


### PR DESCRIPTION
The screenshot on the intro talk page is no longer needed. 
This removes it from the template and from the custom fields.

The center section then looks like this:
<img width="782" alt="image" src="https://user-images.githubusercontent.com/25393215/101744896-5abc6400-3acb-11eb-842a-76b2f0baafdd.png">
