### PR TITLE
Local group page javascript update

### DIFF
--- a/web/app/themes/xrnl/assets/js/xrnl-local-group-tabs.js
+++ b/web/app/themes/xrnl/assets/js/xrnl-local-group-tabs.js
@@ -7,31 +7,31 @@ const sections = ['about', 'demands', 'actions', 'events', 'positions', 'picture
 
 function checkSectionExists(section) {
   if (! jQuery('#' + section).length) {
-    jQuery('#lg-navigation').find('a[href=\'#' + section + '\']').parent().remove();
+    jQuery('#lg-navigation')
+    .find('a[href=\'#' + section + '\']')
+    .parent()
+    .remove();
   }
 }
 
-jQuery(document).ready(function(){
+jQuery(document).ready(function($){
 
   // Remove optional sections from the navigation if they don't exist;
   // If there is only one nav-item left, remove that too.
   sections.forEach(checkSectionExists);
-  if (jQuery('#lg-navigation .nav .nav-item').length < 2){
-    jQuery('#lg-navigation .nav .nav-item').remove();
+  if ($('#lg-navigation .nav .nav-item').length < 2){
+    $('#lg-navigation .nav .nav-item').remove();
   };
 
-  // If the Over Ons section exists, make it active on page load (instead of Contact).
-  if (jQuery('#about-nav').length) {
-    jQuery('#about-nav').tab('show');
+  // If the About Us section exists, make it active on page load (instead of Contact).
+  if ($('#about-nav').length) {
+    $('#about-nav').tab('show');
   }
 
-  // Settings for the picture gallery
-  jQuery(".owl-carousel").owlCarousel({
-    loop:true,
-    margin:5,
-    nav:true,
-    items:1,
-    autoHeight:true
-  });
+  // Needed to initate the carousel
+  if ($('#pictures').length) {
+    $('.carousel-item:first').addClass('active');
+    $('.carousel-indicators > li:first').addClass('active');
+  };
 
 });

--- a/web/app/themes/xrnl/assets/sass/local.scss
+++ b/web/app/themes/xrnl/assets/sass/local.scss
@@ -426,17 +426,6 @@ $logo-bg-bottom-shift: $logo-bottom-shift - ( ($logo-bg-diameter - $logo-diamete
     .picture-gallery {
       min-height: 80vh;
     }
-    .owl-nav {
-      font-family: $brand-font;
-      font-size: 4rem;
-      .owl-prev, .owl-next {
-        margin: 0 1rem;
-        &:hover {
-          background: inherit;
-          color: $xr-primary;
-        }
-      }
-    }
   }
 
   .group-social-icons {

--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -35,6 +35,22 @@ add_action('wp_enqueue_scripts', function(){
 });
 
 
+/**
+ * Custom load javascript for local group pages.
+ */
+function xrnl_lg_scripts() {
+
+  if (is_singular('xrnl_local_group')) {
+    wp_deregister_script('xrnl');
+    wp_enqueue_script('popper-js', get_theme_file_uri('node_modules/popper.js/dist/umd/popper.js'));
+    wp_enqueue_script('bootstrap-js', get_theme_file_uri('node_modules/bootstrap/dist/js/bootstrap.min.js'), array('jquery', 'popper-js'));
+    wp_enqueue_script('xrnl-local-group-tabs', get_theme_file_uri('assets/js/xrnl-local-group-tabs.js'), array('bootstrap-js'));
+  }
+
+}
+add_action( 'wp_enqueue_scripts', 'xrnl_lg_scripts' );
+
+
 add_action('init', function() {
     register_nav_menu('primary', 'Main menu');
     register_nav_menu('primary-mobile', 'Main menu mobile');

--- a/web/app/themes/xrnl/package.json
+++ b/web/app/themes/xrnl/package.json
@@ -24,6 +24,5 @@
         "vue-template-compiler": "^2.5.21"
     },
     "dependencies": {
-        "owl.carousel": "^2.3.4"
     }
 }

--- a/web/app/themes/xrnl/single-xrnl_local_group.php
+++ b/web/app/themes/xrnl/single-xrnl_local_group.php
@@ -347,11 +347,30 @@
         <div class="row">
           <div class="col-12 col-sm-10 col-md-8 col-lg-6 col-xl-6 mx-auto picture-gallery">
             <?php if (is_array($section->picture_gallery)) : ?>
-              <div class="owl-carousel owl-theme">
+            <div id="lg-carousel" class="carousel slide" data-ride="carousel">
+              <ol class="carousel-indicators">
+                <?php for ($i = 0; $i <= count($section->picture_gallery)-1; $i++) : ?>
+                  <li data-target="#lg-carousel" data-slide-to="<?php echo $i ?>"></li>
+                <?php endfor; ?>
+              </ol>
+
+              <div class="carousel-inner">
                 <?php foreach ($section->picture_gallery as $picture) : ?>
-                  <img src="<?php echo($picture['image_url']); ?>" alt="Extinction Rebellion <?php the_field('group_name'); ?>">
+                  <div class="carousel-item">
+                    <img class="d-block w-100" src="<?php echo($picture['image_url']); ?>" alt="Extinction Rebellion <?php the_field('group_name'); ?>">
+                  </div>
                 <?php endforeach; ?>
               </div>
+
+              <a class="carousel-control-prev" href="#lg-carousel" role="button" data-slide="prev">
+                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                <span class="sr-only"><?php _e('Previous', 'theme-xrnl'); ?></span>
+              </a>
+              <a class="carousel-control-next" href="#lg-carousel" role="button" data-slide="next">
+                <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                <span class="sr-only"><?php _e('Next', 'theme-xrnl'); ?></span>
+              </a>
+            </div>
             <?php endif; ?>
           </div>
         </div>

--- a/web/app/themes/xrnl/single-xrnl_local_group.php
+++ b/web/app/themes/xrnl/single-xrnl_local_group.php
@@ -93,14 +93,6 @@
   }
 ?>
 
-<?php
-  wp_enqueue_style('owl-carousel-css', get_template_directory_uri() . '/node_modules/owl.carousel/dist/assets/owl.carousel.min.css');
-  wp_enqueue_style('owl-theme-css', get_template_directory_uri() . '/node_modules/owl.carousel/dist/assets/owl.theme.default.min.css');
-  wp_enqueue_script('bootstrap', get_template_directory_uri() . '/node_modules/bootstrap/dist/js/bootstrap.min.js');
-  wp_enqueue_script('owl-carousel-js', get_template_directory_uri() . '/node_modules/owl.carousel/dist/owl.carousel.min.js');
-  wp_enqueue_script('xrnl-local-group-tabs', get_template_directory_uri() . '/assets/js/xrnl-local-group-tabs.js');
-?>
-
 <div class="local-group">
 
   <div class="lg-hero-container hero-bg-<?php echo $hero_bg_color ?>">


### PR DESCRIPTION
#### 1. Fix a bug that prevents the mobile menu in the top navigation bar from collapsing on local group pages

The bug is caused by the LG template loading `bootstrap.js`. Bootstrap is already included in the compiled `app.js`, so it shouldn't be necessary to load it again in the first place. But for reasons that I still don't really understand, bootstrap functions like `tab()` and `carousel()` are not available with our regular setup when only `app.js` is loaded.

This now resolves the conflict in `functions.php` by first de-registering `app.js`, then loading `bootstrap.min.js`
and then the `xrnl-local-group-tabs.js` script. It only affects local group pages; all other pages work just like before.


#### 2. Get rid of owl carousel
Because:
- owl carousel is no longer in development
- bootstrap already [comes with a carousel](https://getbootstrap.com/docs/4.6/components/carousel/), so we don't need the additional javascript and css
