### PR TITLE
Load svg from theme directory

### DIFF
--- a/web/app/themes/xrnl/single-volunteer_vacancy.php
+++ b/web/app/themes/xrnl/single-volunteer_vacancy.php
@@ -8,7 +8,7 @@ get_header(); ?>
 <?php $volunteerPageURL = get_permalink(apply_filters('wpml_object_id', 51, 'page', true)); ?>
 <article id="post-<?php the_ID(); ?>" ?>
 <div class="row p-2 pt-4 p-md-5 m-2 bg-navy text-white background-icon-container">
-<img src="/app/uploads/2019/04/XR-symbol.svg" class="background-icon">
+<img src="<?php echo get_theme_file_uri('dist/images/XR-symbol.svg'); ?>" class="background-icon">
     <div class="col-12 col-xl-8">
 <a href="<?php echo $volunteerPageURL ?>" class="btn btn-black mb-4"><i class="fas fa-arrow-left"></i>
 <?php _e('View all roles', 'theme-xrnl'); ?>


### PR DESCRIPTION
The background logo on single volunteer pages is missing because apparently it's been deleted from the media library. 
This is now loading the logo from the theme directory instead.

<img width="1228" alt="image" src="https://user-images.githubusercontent.com/25393215/105555630-1b0fab80-5d0a-11eb-928f-f7c1815f6f48.png">
