### PR TITLE
Include online events in local group pages

### DIFF
--- a/web/app/themes/xrnl/single-xrnl_local_group.php
+++ b/web/app/themes/xrnl/single-xrnl_local_group.php
@@ -66,7 +66,6 @@
 
   function getLocalEvents()
   {
-    $place = get_field('place');
     $events_query = array(
       'posts_per_page' => null,
       'paged' => 1,
@@ -86,12 +85,12 @@
           'relation' => 'OR',
           array(
             'key' => 'venue_city',
-            'value' => $place,
+            'value' => get_field('place'),
             'compare' => '='
           ),
           array(
             'key' => 'organizer_name',
-            'value' => $place,
+            'value' => get_field('group_name'),
             'compare' => 'REGEXP'
           )
         )

--- a/web/app/themes/xrnl/single-xrnl_local_group.php
+++ b/web/app/themes/xrnl/single-xrnl_local_group.php
@@ -66,6 +66,7 @@
 
   function getLocalEvents()
   {
+    $place = get_field('place');
     $events_query = array(
       'posts_per_page' => null,
       'paged' => 1,
@@ -74,6 +75,7 @@
       'meta_key' => 'event_start_date',
       'order' => 'ASC',
       'meta_query' => array(
+        'relation' => 'AND',
         array(
           'key' => 'event_start_date',
           'value' => date("Y-m-d"),
@@ -81,9 +83,17 @@
           'type' => 'DATE'
         ),
         array(
-          'key' => 'venue_city',
-          'value' => get_field('place'),
-          'compare' => '='
+          'relation' => 'OR',
+          array(
+            'key' => 'venue_city',
+            'value' => $place,
+            'compare' => '='
+          ),
+          array(
+            'key' => 'organizer_name',
+            'value' => $place,
+            'compare' => 'REGEXP'
+          )
         )
       )
     );


### PR DESCRIPTION
Hey, I've been meaning to suggest this for a while but there was also a request on MM about it recently.

It would good if the events tab on LG pages showed not only real-life events from the same place, but also
- online events that are organized by the group
- any events organized by multiple groups, where the group is co-organizer

The new filter for the main Events page will use the `Organizer name` field for those cases, which is already being filled in for most events on the website. But we don't have to wait for the filters on the main Events page to be ready before we can use it for the events tab on LG pages.

This PR adjusts the events query to include any events
- matching in physical location (using the `venue_city` field, as before)
- mentioning the group name in the `organizer_name` field.


### Before
![events_before](https://user-images.githubusercontent.com/25393215/107373072-68e82a00-6ae6-11eb-8efe-99f3e854a800.png)

### After

![events_after](https://user-images.githubusercontent.com/25393215/107373115-730a2880-6ae6-11eb-8127-3b8131eb8677.png)

### Now matching group name to the value of this field:
<img width="820" alt="image" src="https://user-images.githubusercontent.com/25393215/107373941-5b7f6f80-6ae7-11eb-81e9-c8943d86a8e8.png">

It will match `Rotterdam`, `XR Rotterdam`, `extinction rebellion rotterdam`, `XR Utrecht & XR Rotterdam`, ...