### PR TITLE
Re-position image navigation for local group pages

### DIFF
--- a/web/app/themes/xrnl/assets/sass/local.scss
+++ b/web/app/themes/xrnl/assets/sass/local.scss
@@ -425,6 +425,25 @@ $logo-bg-bottom-shift: $logo-bottom-shift - ( ($logo-bg-diameter - $logo-diamete
   #pictures {
     .picture-gallery {
       min-height: 80vh;
+      .carousel-control-prev-icon,
+      .carousel-control-next-icon {
+        background-color: $xr-black;
+        padding: .9rem;
+        &:hover {
+          background-color: $xr-primary;
+        }
+      }
+      .carousel-control-prev,
+      .carousel-control-next {
+        align-items: flex-start;
+        opacity: 1;
+      }
+      .carousel-control-prev {
+        justify-content: flex-start;
+      }
+      .carousel-control-next {
+        justify-content: flex-end;
+      }
     }
   }
 


### PR DESCRIPTION
Moving the controls to the top, as [discussed previously](https://github.com/xrnl/extinction-rebellion-nl/pull/118#issuecomment-766880665).

To my eye it looks a bit less awkward when they are in the top corners, rather than above the images. Comments welcome :)

<img width="570" alt="image" src="https://user-images.githubusercontent.com/25393215/107931816-16db5480-6f7d-11eb-9a7d-0dd0d3507ec6.png">

Mobile, also showing highlight on hover:
<img width="124" alt="image" src="https://user-images.githubusercontent.com/25393215/107932057-6a4da280-6f7d-11eb-818d-f35ef0190eb9.png">
