### PR TITLE
Filter events by organizer instead of location

### DIFF
--- a/web/app/themes/xrnl/archive-meetup_events.php
+++ b/web/app/themes/xrnl/archive-meetup_events.php
@@ -11,12 +11,12 @@ $param_type = stripslashes(get_query_var('type'));
 // organizer query
 $query_organizer = $param_organizer ? array(
 	'key' => 'organizer_name',
-	'value' => $param_organizer,
-	'compare' => '='
+	'value' => array($param_organizer, 'Extinction Rebellion NL'),
+	'compare' => 'IN'
 ) : array();
 
 // type query
-$query_type = $param_type ? array(
+$query_type = $param_type ? array( 
 	'key' => 'venue_address',
 	'value' => 'Online',
 	'compare' => ($param_type == 'Online') ? '=' : '!='

--- a/web/app/themes/xrnl/archive-meetup_events.php
+++ b/web/app/themes/xrnl/archive-meetup_events.php
@@ -4,15 +4,14 @@
  * Template name: Events
  */
 
-// city query param
-$param_city = stripslashes(get_query_var('city'));
+$param_organizer = stripslashes(get_query_var('organizer'));
 $param_category = stripslashes(get_query_var('category'));
 $param_type = stripslashes(get_query_var('type'));
 
-// city query
-$query_city = $param_city ? array(
-	'key' => 'venue_city',
-	'value' => $param_city,
+// organizer query
+$query_organizer = $param_organizer ? array(
+	'key' => 'organizer_name',
+	'value' => $param_organizer,
 	'compare' => '='
 ) : array();
 
@@ -41,7 +40,7 @@ $args = array(
 			'compare' => '>=', // Return the ones greater than today's date
 			'type' => 'DATE' // Let WordPress know we're working with date
 		),
-		$query_city,
+		$query_organizer,
 		$query_type
 	)
 );
@@ -89,22 +88,22 @@ get_header(); ?>
 		</div>
 	<?php endif; ?>
 
-	<h1 class="page-title"><?php _e('EVENTS'); ?> <?php echo $param_city; ?></h1>
+	<h1 class="page-title"><?php _e('EVENTS'); ?> <?php echo $param_organizer; ?></h1>
 	<p><?php the_field('intro_text', $events_page_id); ?></p>
 
-	<?php if ($param_values['cities'] || $param_values['categories'] || $param_values['types']) { ?>
+	<?php if ($param_values['organizers'] || $param_values['categories'] || $param_values['types']) { ?>
 		<form class="mt-4 flex-nowrap" method="get">
 			<div class="form-row">
 				<input type="hidden" name="paged" value="1" />
-				<?php if ($param_values['cities']) { ?>
-					<label class="my-1 mr-sm-2" for="city"><?php _e('Location') ?></label>
+				<?php if ($param_values['organizers']) { ?>
+					<label class="my-1 mr-sm-2" for="organizer"><?php _e('Organizer') ?></label>
 					<div class="col-sm-3">
-						<select name="city" class="custom-select my-1 form-control" id="city">
+						<select name="organizer" class="custom-select my-1 form-control" id="organizer">
 							<option value=""><?php _e('All') ?></option>
 							<option disabled>──────</option>
-							<?php foreach ($param_values['cities'] as $city => $count) { ?>
-								<option value="<?php echo $city ?>" <?php echo $param_city == $city ? 'selected="selected"' : '' ?>>
-									<?php echo $city . ' (' . $count . ')' ?>
+							<?php foreach ($param_values['organizers'] as $organizer => $count) { ?>
+								<option value="<?php echo $organizer ?>" <?php echo $param_organizer == $organizer ? 'selected="selected"' : '' ?>>
+									<?php echo $organizer . ' (' . $count . ')' ?>
 								</option>
 							<?php } ?>
 						</select>

--- a/web/app/themes/xrnl/archive-meetup_events.php
+++ b/web/app/themes/xrnl/archive-meetup_events.php
@@ -11,7 +11,8 @@ $param_category = stripslashes(get_query_var('category'));
 $query_organizer = $param_organizer ? array(
 	'key' => 'organizer_name',
 	'value' => $param_organizer,
-	'compare' => '='
+	'compare' => '=',
+	'sentence' => true
 ) : array();
 
 // page query param

--- a/web/app/themes/xrnl/archive-meetup_events.php
+++ b/web/app/themes/xrnl/archive-meetup_events.php
@@ -6,20 +6,12 @@
 
 $param_organizer = stripslashes(get_query_var('organizer'));
 $param_category = stripslashes(get_query_var('category'));
-$param_type = stripslashes(get_query_var('type'));
 
 // organizer query
 $query_organizer = $param_organizer ? array(
 	'key' => 'organizer_name',
-	'value' => array($param_organizer, 'Extinction Rebellion NL'),
-	'compare' => 'IN'
-) : array();
-
-// type query
-$query_type = $param_type ? array( 
-	'key' => 'venue_address',
-	'value' => 'Online',
-	'compare' => ($param_type == 'Online') ? '=' : '!='
+	'value' => $param_organizer,
+	'compare' => '='
 ) : array();
 
 // page query param
@@ -40,8 +32,7 @@ $args = array(
 			'compare' => '>=', // Return the ones greater than today's date
 			'type' => 'DATE' // Let WordPress know we're working with date
 		),
-		$query_organizer,
-		$query_type
+		$query_organizer
 	)
 );
 // push the taxonomy search if the category parameter is found:
@@ -91,7 +82,7 @@ get_header(); ?>
 	<h1 class="page-title"><?php _e('EVENTS'); ?> <?php echo $param_organizer; ?></h1>
 	<p><?php the_field('intro_text', $events_page_id); ?></p>
 
-	<?php if ($param_values['organizers'] || $param_values['categories'] || $param_values['types']) { ?>
+	<?php if ($param_values['organizers'] || $param_values['categories']) { ?>
 		<form class="mt-4 flex-nowrap" method="get">
 			<div class="form-row">
 				<input type="hidden" name="paged" value="1" />
@@ -118,20 +109,6 @@ get_header(); ?>
 							<?php foreach ($param_values['categories'] as $category => $count) { ?>
 								<option value="<?php echo $category ?>" <?php echo $param_category == $category ? 'selected="selected"' : '' ?>>
 									<?php echo $category . ' (' . $count . ')' ?>
-								</option>
-							<?php } ?>
-						</select>
-					</div>
-				<?php } ?>
-				<?php if ($param_values['types']) { ?>
-					<label class="my-1 mx-sm-2" for="type"><?php _e('Online/Offline') ?></label>
-					<div class="col-sm-3">
-						<select name="type" class="custom-select my-1 form-control" id="type">
-							<option value=""><?php _e('All') ?></option>
-							<option disabled>──────</option>
-							<?php foreach ($param_values['types'] as $type => $count) { ?>
-								<option value="<?php echo $type ?>" <?php echo $param_type == $type ? 'selected="selected"' : '' ?>>
-									<?php echo $type . ' (' . $count . ')' ?>
 								</option>
 							<?php } ?>
 						</select>

--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -296,18 +296,18 @@ function event_params() {
     );
 
     $events = new WP_Query( $args );
-    $cities = array();
+    $organizers = array();
     $categories = array();
     $types = array();
 
     while ( $events->have_posts() ) {
         $events->the_post();
-        $city = get_post_meta( get_the_ID(), 'venue_city', true );
-        if ($city != ''){
-            if (array_key_exists($city, $cities)) {
-                $cities[$city]++;
+        $organizer = get_post_meta( get_the_ID(), 'organizer_name', true );
+        if ($organizer != ''){
+            if (array_key_exists($organizer, $organizers)) {
+                $organizers[$organizer]++;
             } else {
-                $cities[$city] = 1;
+                $organizers[$organizer] = 1;
             }
         }
         $venue = get_post_meta( get_the_ID(), 'venue_address', true );
@@ -333,12 +333,12 @@ function event_params() {
             }
         }
     }
-    ksort($cities);
+    ksort($organizers);
     ksort($categories);
     ksort($types);
 
     return array(
-        'cities'  => $cities,
+        'organizers'  => $organizers,
         'categories' => $categories,
         'types' => $types,
     );
@@ -369,7 +369,7 @@ function vacancy_groups( $vacancies ) {
 }
 
 function xrnl_query_vars( $qvars ) {
-    $qvars[] = 'city';
+    $qvars[] = 'organizer';
     $qvars[] = 'category';
     $qvars[] = 'type';
     $qvars[] = 'working_group';

--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -298,7 +298,6 @@ function event_params() {
     $events = new WP_Query( $args );
     $organizers = array();
     $categories = array();
-    $types = array();
 
     while ( $events->have_posts() ) {
         $events->the_post();
@@ -311,12 +310,6 @@ function event_params() {
             }
         }
         $venue = get_post_meta( get_the_ID(), 'venue_address', true );
-        $type = ($venue == 'Online') ? 'Online' : 'Offline';
-        if (array_key_exists($type, $types)) {
-            $types[$type]++;
-        } else {
-            $types[$type] = 1;
-        }
 
         $term_obj_list = get_the_terms(get_the_ID(), 'meetup_category');
         if($term_obj_list) {
@@ -333,23 +326,13 @@ function event_params() {
             }
         }
     }
-    if (array_key_exists('Extinction Rebellion NL', $organizers)) {
-        $n_national_events = $organizers['Extinction Rebellion NL'];
-        foreach ($organizers as $organizer => $count) {
-            if ($organizer != 'Extinction Rebellion NL'){
-                $organizers[$organizer] += $n_national_events;
-            }
-        }
-    }
 
     ksort($organizers);
     ksort($categories);
-    ksort($types);
 
     return array(
         'organizers'  => $organizers,
-        'categories' => $categories,
-        'types' => $types,
+        'categories' => $categories
     );
 }
 

--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -333,6 +333,15 @@ function event_params() {
             }
         }
     }
+    if (array_key_exists('Extinction Rebellion NL', $organizers)) {
+        $n_national_events = $organizers['Extinction Rebellion NL'];
+        foreach ($organizers as $organizer => $count) {
+            if ($organizer != 'Extinction Rebellion NL'){
+                $organizers[$organizer] += $n_national_events;
+            }
+        }
+    }
+
     ksort($organizers);
     ksort($categories);
     ksort($types);


### PR DESCRIPTION
Currently, events are filtered by location where all online events are grouped into one item - Issue with that is that we are mixing events from different local groups while users would want to see events of a local group specifically. This MR solves this by replacing the location-based filter with a filter by organizer.

Downside of this solution is that the 'Organizer' field is not always consistently used (e.g. Extinction Rebellion vs XR) and that they can be quite lengthy - see screenshot below:

![image](https://user-images.githubusercontent.com/38844035/108626755-139b0980-7452-11eb-892d-abaf4b46a4d1.png)
