### PR TITLE
Local group page updates

### DIFF
--- a/web/app/themes/xrnl/acf-json/group_5f1ad30f2103e.json
+++ b/web/app/themes/xrnl/acf-json/group_5f1ad30f2103e.json
@@ -3,6 +3,24 @@
     "title": "Local group",
     "fields": [
         {
+            "key": "field_60327fcb79fd0",
+            "label": "Instructions",
+            "name": "",
+            "type": "message",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "message": "Check out <a href=\"https:\/\/cloud.extinctionrebellion.nl\/index.php\/s\/3eF2cnetwEHRxFk\">this document<\/a> for more information on how to fill in the fields below.",
+            "new_lines": "wpautop",
+            "esc_html": 0
+        },
+        {
             "key": "field_5f43aecadd569",
             "label": "Group name",
             "name": "group_name",
@@ -432,7 +450,7 @@
                     "label": "Content",
                     "name": "content",
                     "type": "textarea",
-                    "instructions": "",
+                    "instructions": "Use line breaks to start a new paragraph",
                     "required": 0,
                     "conditional_logic": 0,
                     "wrapper": {
@@ -440,12 +458,12 @@
                         "class": "",
                         "id": ""
                     },
+                    "wpml_cf_preferences": 0,
                     "default_value": "",
                     "placeholder": "",
                     "maxlength": "",
-                    "rows": "",
-                    "new_lines": "",
-                    "wpml_cf_preferences": 0
+                    "rows": 10,
+                    "new_lines": "wpautop"
                 },
                 {
                     "key": "field_5f478d570a024",
@@ -547,7 +565,7 @@
                     "collapsed": "",
                     "min": 0,
                     "max": 0,
-                    "layout": "table",
+                    "layout": "row",
                     "button_label": "Add Demand",
                     "sub_fields": [
                         {
@@ -574,8 +592,8 @@
                             "key": "field_5f240df920522",
                             "label": "Description",
                             "name": "description",
-                            "type": "text",
-                            "instructions": "",
+                            "type": "textarea",
+                            "instructions": "Use line breaks to start a new paragraph",
                             "required": 0,
                             "conditional_logic": 0,
                             "wrapper": {
@@ -583,12 +601,12 @@
                                 "class": "",
                                 "id": ""
                             },
-                            "wpml_cf_preferences": 0,
                             "default_value": "",
                             "placeholder": "",
-                            "prepend": "",
-                            "append": "",
-                            "maxlength": ""
+                            "maxlength": "",
+                            "rows": "",
+                            "new_lines": "wpautop",
+                            "wpml_cf_preferences": 0
                         }
                     ]
                 }
@@ -667,7 +685,7 @@
                     "collapsed": "",
                     "min": 0,
                     "max": 0,
-                    "layout": "table",
+                    "layout": "row",
                     "button_label": "Add Action",
                     "sub_fields": [
                         {
@@ -695,7 +713,7 @@
                             "label": "Description",
                             "name": "description",
                             "type": "textarea",
-                            "instructions": "",
+                            "instructions": "Use line breaks to start a new paragraph",
                             "required": 0,
                             "conditional_logic": 0,
                             "wrapper": {
@@ -703,12 +721,12 @@
                                 "class": "",
                                 "id": ""
                             },
+                            "wpml_cf_preferences": 0,
                             "default_value": "",
                             "placeholder": "",
                             "maxlength": "",
-                            "rows": "",
-                            "new_lines": "",
-                            "wpml_cf_preferences": 0
+                            "rows": 10,
+                            "new_lines": "wpautop"
                         },
                         {
                             "key": "field_5f478e018a629",
@@ -838,7 +856,7 @@
                     "label": "Show section",
                     "name": "enabled",
                     "type": "true_false",
-                    "instructions": "Shows local events tab if there are any events (for the place that is entered in the <a href=\"#lg-place\">place<\/a> field)",
+                    "instructions": "If there are any events that are organised by the group, or are in the same <a href=\"#lg-place\">place<\/a>, they will appear in the Events tab when this is checked.",
                     "required": 0,
                     "conditional_logic": 0,
                     "wrapper": {
@@ -1178,5 +1196,5 @@
     "hide_on_screen": "",
     "active": true,
     "description": "",
-    "modified": 1605130535
+    "modified": 1613923757
 }

--- a/web/app/themes/xrnl/assets/js/xrnl-local-group-tabs.js
+++ b/web/app/themes/xrnl/assets/js/xrnl-local-group-tabs.js
@@ -23,6 +23,12 @@ jQuery(document).ready(function($){
     $('#lg-navigation .nav .nav-item').remove();
   };
 
+  // See if a specific tab was requested in the URL
+  let URLParam = window.location.hash.substring(1);
+  if (sections.includes(URLParam)) {
+    var navID = ['#', URLParam, '-nav'].join('');
+  }
+
   // If the About Us section exists, make it active on page load (instead of Contact).
   if ($('#about-nav').length) {
     $('#about-nav').tab('show');

--- a/web/app/themes/xrnl/assets/js/xrnl-local-group-tabs.js
+++ b/web/app/themes/xrnl/assets/js/xrnl-local-group-tabs.js
@@ -29,12 +29,18 @@ jQuery(document).ready(function($){
     var navID = ['#', URLParam, '-nav'].join('');
   }
 
-  // If the About Us section exists, make it active on page load (instead of Contact).
-  if ($('#about-nav').length) {
+  // On page load, show the requested tab if it exists
+  // If no specific tab was requested, show the About-us section if it exists
+  // Otherwise, show the Contact tab as default
+  if ($(navID).length) {
+    $(navID).tab('show');
+  } else if ($('#about-nav').length) {
     $('#about-nav').tab('show');
+  } else {
+    $('#contact-nav').tab('show');
   }
 
-  // Needed to initate the carousel
+  // Initiate the carousel
   if ($('#pictures').length) {
     $('.carousel-item:first').addClass('active');
     $('.carousel-indicators > li:first').addClass('active');

--- a/web/app/themes/xrnl/assets/sass/local.scss
+++ b/web/app/themes/xrnl/assets/sass/local.scss
@@ -296,7 +296,7 @@ $logo-bg-bottom-shift: $logo-bottom-shift - ( ($logo-bg-diameter - $logo-diamete
 
   .actions-list {
     .action-item {
-      margin-top: 1.2rem;
+      margin-top: 3rem;
       .action-item-title {
         font-family: $brand-font;
         font-size: 1.4rem;

--- a/web/app/themes/xrnl/single-xrnl_local_group.php
+++ b/web/app/themes/xrnl/single-xrnl_local_group.php
@@ -215,7 +215,7 @@
         <div class="row">
           <div class="col-12 col-sm-10 col-md-8 col-lg-6 col-xl-6 mx-auto">
             <h1><?php echo($section->heading); ?></h1>
-            <p><?php echo($section->content); ?></p>
+            <div><?php echo($section->content); ?></div>
             <?php if (!empty($section->picture_url)) : ?>
               <img src="<?php echo($section->picture_url); ?>" alt="Extinction Rebellion <?php the_field('group_name'); ?>">
             <?php endif; ?>
@@ -235,7 +235,7 @@
                 <?php foreach ($section->demands_list as $demand) : ?>
                 <div class="demands-item">
                   <h5 class="demands-item-title"><?php echo($demand['title']); ?></h5>
-                  <p class="demands-item-desc"><?php echo($demand['description']); ?></p>
+                  <div class="demands-item-desc"><?php echo($demand['description']); ?></div>
                 </div>
                 <?php endforeach; ?>
               </div>
@@ -256,7 +256,7 @@
                 <?php foreach ($section->actions_list as $action) : ?>
                 <div class="action-item">
                   <h5 class="action-item-title"><?php echo($action['title']); ?></h5>
-                  <p class="action-item-desc"><?php echo($action['description']); ?></p>
+                  <div class="action-item-desc"><?php echo($action['description']); ?></div>
                   <?php if (isset($action['picture_url'])) : ?>
                     <img src="<?php echo($action['picture_url']); ?>" alt="Extinction Rebellion <?php the_field('group_name'); ?>">
                   <?php endif; ?>


### PR DESCRIPTION
Some minor improvements for the local group pages:

#### 1. Add support for loading specific tabs on LG pages
In `xrnl-local-group-tabs.js`
This now checks if there is a hash parameter in the URL that matches one of the tabs, and if so, makes that tab active when the page loads. 

So LGs can use URLs like `extinctionrebellion.nl/groep/amsterdam#actions` to point directly to the Actions tab, for example.

#### 2. Small update for the custom fields:
In `group_5f1ad30f2103e.json`
- Add a link to the more detailed [instructions](https://cloud.extinctionrebellion.nl/index.php/s/3eF2cnetwEHRxFk) on NC 
- Update the help text for the events section to reflect the recent change in #125
- In the About us, Demands, and Actions sections, line breaks in the text box will now automatically insert `<p>` tags ([addressing this question](https://organise.earth/xr-netherlands/pl/ms8bxm3mh7gkjbnf3j6exiuxbc) on MM). Because of this, there are also some small formatting adjustments in the css and template file.

##### Without automatic `<p>` tags
<img width="1327" alt="image" src="https://user-images.githubusercontent.com/25393215/108710663-a9976880-7514-11eb-94a0-191abbd99f8b.png">

##### With automatic `<p>` tags
<img width="1323" alt="image" src="https://user-images.githubusercontent.com/25393215/108710857-e2cfd880-7514-11eb-9063-c2223c1bf7c4.png">
