### PR TITLE
Community group update

### DIFF
--- a/web/app/themes/xrnl/acf-json/group_5e903166ebd61.json
+++ b/web/app/themes/xrnl/acf-json/group_5e903166ebd61.json
@@ -4,7 +4,7 @@
     "fields": [
         {
             "key": "field_5e903237e1f61",
-            "label": "Group",
+            "label": "Community group",
             "name": "group",
             "type": "group",
             "instructions": "",
@@ -34,26 +34,6 @@
                     "wpml_cf_preferences": 0,
                     "default_value": "https:\/\/extinctionrebellion.nl\/app\/uploads\/2020\/04\/community-group.png",
                     "placeholder": ""
-                },
-                {
-                    "key": "field_5e9cb0c1b32fa",
-                    "label": "Darkened cover image",
-                    "name": "cover_image_darkened",
-                    "type": "true_false",
-                    "instructions": "",
-                    "required": 0,
-                    "conditional_logic": 0,
-                    "wrapper": {
-                        "width": "",
-                        "class": "",
-                        "id": ""
-                    },
-                    "wpml_cf_preferences": 0,
-                    "message": "Dark gradient overlay and white text on the cover image",
-                    "default_value": 1,
-                    "ui": 0,
-                    "ui_on_text": "",
-                    "ui_off_text": ""
                 },
                 {
                     "key": "field_5e94830a5e544",
@@ -96,8 +76,25 @@
                     "maxlength": ""
                 },
                 {
+                    "key": "field_6059c9c603240",
+                    "label": "Twitter",
+                    "name": "twitter_url",
+                    "type": "url",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": "",
+                    "wpml_cf_preferences": 0
+                },
+                {
                     "key": "field_5e903237e1f68",
-                    "label": "Facebook page",
+                    "label": "Facebook",
                     "name": "facebook_url",
                     "type": "url",
                     "instructions": "",
@@ -114,7 +111,7 @@
                 },
                 {
                     "key": "field_5e903237e1f69",
-                    "label": "Instagram page",
+                    "label": "Instagram",
                     "name": "instagram_url",
                     "type": "url",
                     "instructions": "",
@@ -131,7 +128,7 @@
                 },
                 {
                     "key": "field_5e942bd1a676a",
-                    "label": "YouTube channel",
+                    "label": "YouTube",
                     "name": "youtube_url",
                     "type": "url",
                     "instructions": "",
@@ -142,9 +139,9 @@
                         "class": "",
                         "id": ""
                     },
+                    "wpml_cf_preferences": 0,
                     "default_value": "",
-                    "placeholder": "",
-                    "wpml_cf_preferences": 0
+                    "placeholder": ""
                 },
                 {
                     "key": "field_5e903237e1f6a",
@@ -164,6 +161,216 @@
                     "placeholder": "",
                     "prepend": "",
                     "append": ""
+                },
+                {
+                    "key": "field_605a5aec66254",
+                    "label": "Link buttons",
+                    "name": "link_buttons",
+                    "type": "repeater",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "collapsed": "",
+                    "min": 0,
+                    "max": 0,
+                    "layout": "table",
+                    "button_label": "Add button",
+                    "wpml_cf_preferences": 0,
+                    "sub_fields": [
+                        {
+                            "key": "field_605a5b1e66255",
+                            "label": "Label",
+                            "name": "label",
+                            "type": "text",
+                            "instructions": "The text label for the button",
+                            "required": 1,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "wpml_cf_preferences": 0,
+                            "default_value": "",
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "",
+                            "maxlength": ""
+                        },
+                        {
+                            "key": "field_605a5b2966256",
+                            "label": "Target URL",
+                            "name": "target_url",
+                            "type": "url",
+                            "instructions": "The target URL for the button",
+                            "required": 1,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "default_value": "",
+                            "placeholder": "",
+                            "wpml_cf_preferences": 0
+                        },
+                        {
+                            "key": "field_605a5ba766257",
+                            "label": "Colour",
+                            "name": "colour",
+                            "type": "select",
+                            "instructions": "The background color of the button",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "choices": {
+                                "black": "Black",
+                                "green": "Green"
+                            },
+                            "default_value": "black",
+                            "allow_null": 0,
+                            "multiple": 0,
+                            "ui": 0,
+                            "return_format": "value",
+                            "wpml_cf_preferences": 0,
+                            "ajax": 0,
+                            "placeholder": ""
+                        }
+                    ]
+                },
+                {
+                    "key": "field_605a291c545f2",
+                    "label": "Picture gallery",
+                    "name": "picture_gallery",
+                    "type": "group",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "layout": "block",
+                    "wpml_cf_preferences": 0,
+                    "sub_fields": [
+                        {
+                            "key": "field_605a295b545f3",
+                            "label": "Heading",
+                            "name": "heading",
+                            "type": "text",
+                            "instructions": "This is optional",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "wpml_cf_preferences": 0,
+                            "default_value": "",
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "",
+                            "maxlength": ""
+                        },
+                        {
+                            "key": "field_605a2979545f4",
+                            "label": "Description",
+                            "name": "description",
+                            "type": "textarea",
+                            "instructions": "This is optional",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "wpml_cf_preferences": 0,
+                            "default_value": "",
+                            "placeholder": "",
+                            "maxlength": "",
+                            "rows": 4,
+                            "new_lines": "wpautop"
+                        },
+                        {
+                            "key": "field_605a562ddd5fb",
+                            "label": "Pictures",
+                            "name": "pictures",
+                            "type": "repeater",
+                            "instructions": "Select images from the media library in order to add up to 35 pictures. The maximum size for one picture is 1.5MB.\r\nCaptions are optional.",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "wpml_cf_preferences": 0,
+                            "collapsed": "",
+                            "min": 0,
+                            "max": 35,
+                            "layout": "row",
+                            "button_label": "Add picture",
+                            "sub_fields": [
+                                {
+                                    "key": "field_605a56b6dd5fc",
+                                    "label": "Picture",
+                                    "name": "picture",
+                                    "type": "image",
+                                    "instructions": "",
+                                    "required": 1,
+                                    "conditional_logic": 0,
+                                    "wrapper": {
+                                        "width": "",
+                                        "class": "",
+                                        "id": ""
+                                    },
+                                    "wpml_cf_preferences": 0,
+                                    "return_format": "url",
+                                    "preview_size": "thumbnail",
+                                    "library": "all",
+                                    "min_width": "",
+                                    "min_height": "",
+                                    "min_size": "",
+                                    "max_width": "",
+                                    "max_height": "",
+                                    "max_size": "1.5",
+                                    "mime_types": ""
+                                },
+                                {
+                                    "key": "field_605a570add5fd",
+                                    "label": "Caption",
+                                    "name": "caption",
+                                    "type": "text",
+                                    "instructions": "140 characters max.",
+                                    "required": 0,
+                                    "conditional_logic": 0,
+                                    "wrapper": {
+                                        "width": "",
+                                        "class": "",
+                                        "id": ""
+                                    },
+                                    "wpml_cf_preferences": 0,
+                                    "default_value": "",
+                                    "placeholder": "",
+                                    "prepend": "",
+                                    "append": "",
+                                    "maxlength": 140
+                                }
+                            ]
+                        }
+                    ]
                 }
             ]
         }
@@ -183,7 +390,7 @@
     "label_placement": "top",
     "instruction_placement": "label",
     "hide_on_screen": "",
-    "active": 1,
+    "active": true,
     "description": "",
-    "modified": 1587328727
+    "modified": 1616664604
 }

--- a/web/app/themes/xrnl/acf-json/group_5e903166ebd61.json
+++ b/web/app/themes/xrnl/acf-json/group_5e903166ebd61.json
@@ -308,7 +308,7 @@
                             "label": "Pictures",
                             "name": "pictures",
                             "type": "repeater",
-                            "instructions": "Select images from the media library in order to add up to 35 pictures. The maximum size for one picture is 1.5MB.\r\nCaptions are optional.",
+                            "instructions": "To prevent the page from becoming too slow, the maximum number of pictures is 35. To share more (or higher-resolution) pictures, one option is to put them in a shared folder on nextcloud, and link to that with a button. \r\nCaptions are optional.",
                             "required": 0,
                             "conditional_logic": 0,
                             "wrapper": {
@@ -392,5 +392,5 @@
     "hide_on_screen": "",
     "active": true,
     "description": "",
-    "modified": 1616664604
+    "modified": 1617610553
 }

--- a/web/app/themes/xrnl/assets/sass/community.scss
+++ b/web/app/themes/xrnl/assets/sass/community.scss
@@ -42,6 +42,13 @@
     }
   }
 
+  .main-content {
+    text-align: left;
+    @include media-breakpoint-up(md) {
+      text-align: justify;
+    };
+  }
+
   .picture-gallery {
     .carousel-control-prev-icon,
     .carousel-control-next-icon {

--- a/web/app/themes/xrnl/assets/sass/community.scss
+++ b/web/app/themes/xrnl/assets/sass/community.scss
@@ -44,4 +44,32 @@
       }
     }
   }
+
+  .picture-gallery {
+    .carousel-control-prev-icon,
+    .carousel-control-next-icon {
+      background-color: $xr-black;
+      padding: .8rem;
+      &:hover {
+        background-color: $xr-primary;
+      }
+    }
+    .carousel-control-prev,
+    .carousel-control-next {
+      align-items: flex-start;
+      opacity: 1;
+    }
+    .carousel-control-prev {
+      justify-content: flex-start;
+    }
+    .carousel-control-next {
+      justify-content: flex-end;
+    }
+    .carousel-caption {
+      position: relative;
+      left: 0;
+      top: 0;
+    }
+  }
+
 }

--- a/web/app/themes/xrnl/assets/sass/community.scss
+++ b/web/app/themes/xrnl/assets/sass/community.scss
@@ -26,18 +26,13 @@
 
 .community-group {
   .hero-container {
-    position: relative;
+    text-align: center;
   }
   .group-cover-image {
-    min-height: 80vh;
-    background-size: cover !important;
-    background-position: center !important;
+    max-height: 55vh;
   }
   .hero-caption {
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    text-align: right;
+    font-size: .9rem;
   }
   .group-slogan {
     margin-top: 3rem;

--- a/web/app/themes/xrnl/assets/sass/community.scss
+++ b/web/app/themes/xrnl/assets/sass/community.scss
@@ -16,11 +16,8 @@
       object-fit: cover;
     }
   }
-  @include media-breakpoint-down(xs) {
-    .group-column {
-      margin-left: auto;
-      margin-right: auto;
-    }
+  .card-footer {
+    padding: 0 .5rem;
   }
 }
 

--- a/web/app/themes/xrnl/community_group-archive.php
+++ b/web/app/themes/xrnl/community_group-archive.php
@@ -31,7 +31,7 @@ get_header(); ?>
 
             <?php $img_url = get_field('group_cover_image_url') ?: $default_img_url;  // Use default pic if cover image is missing ?>
             <a href="<?php the_permalink(); ?>">
-              <img src="<?php echo($img_url); ?>" class="card-img-top" alt="XRNL Community group">
+              <img src="<?php echo($img_url); ?>" class="card-img-top" alt="<?php the_title(); ?>">
             </a>
 
                <a href="<?php the_permalink(); ?>"><h5 class="card-header text-center font-xr text-uppercase bg-yellow border-0"><?php the_title(); ?></h5></a>

--- a/web/app/themes/xrnl/community_group-archive.php
+++ b/web/app/themes/xrnl/community_group-archive.php
@@ -42,6 +42,10 @@ get_header(); ?>
               </div>
 
               <div class="card-footer bg-light border-0 text-center">
+               <?php if(get_field('group_twitter_url')): ?>
+                 <a href="<?php the_field('group_twitter_url'); ?>"  target="_blank" rel="noreferrer noopener" class="btn twitter" aria-label="twitter"><i class="fab fa-2x fa-twitter"></i></a>
+               <?php endif; ?>
+
                <?php if(get_field('group_facebook_url')): ?>
                  <a href="<?php the_field('group_facebook_url'); ?>"  target="_blank" rel="noreferrer noopener" class="btn facebook" aria-label="facebook"><i class="fab fa-2x fa-facebook-f"></i></a>
                <?php endif; ?>

--- a/web/app/themes/xrnl/community_group-archive.php
+++ b/web/app/themes/xrnl/community_group-archive.php
@@ -7,7 +7,7 @@ get_header(); ?>
 
 <?php
   $groups = new WP_Query([
-    'order' => 'DESC',
+    'order' => 'ASC',
     'orderby' => 'ID',
     'post_type' => 'community_group',
     'posts_per_page' => -1
@@ -16,32 +16,26 @@ get_header(); ?>
 ?>
 
 <div id="community" class="container py-5">
-    <h1 class="mt-5"><?php the_title(); ?></h1>
-    <p><?php the_content(); ?></p>
+    <div class="row text-center">
+      <div class="col col-sm-11 col-md-10 col-lg-8 mx-auto">
+        <h1 class="display-3"><?php the_title(); ?></h1>
+        <p><?php the_content(); ?></p>
+      </div>
+    </div>
 
-    <div class="row">
+    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3">
       <?php while($groups->have_posts()):$groups->the_post(); ?>
-        <?php $show_link_to_group_page = !empty(get_the_content()); // Show link if group has content text ?>
+      <div class="col mb-4 mt-4">
 
-        <div class="col-8 col-sm-6 col-md-4 col-xl-4 mt-4 group-column">
-          <div id="group-card-<?php echo($groups->current_post); ?>" class="card group-card h-100 border-0">
+          <div id="group-card-<?php echo($groups->current_post); ?>" class="card group-card border-0">
 
             <?php $img_url = get_field('group_cover_image_url') ?: $default_img_url;  // Use default pic if cover image is missing ?>
-            <img src="<?php echo($img_url); ?>" class="card-img-top" alt="XRNL Community group">
+            <a href="<?php the_permalink(); ?>">
+              <img src="<?php echo($img_url); ?>" class="card-img-top" alt="XRNL Community group">
+            </a>
 
-             <?php if($show_link_to_group_page): ?>
-               <a href="<?php the_permalink(); ?>"><h5 class="card-header font-xr text-uppercase bg-yellow border-0"><?php the_title(); ?></h5></a>
-             <?php else :?>
-              <h5 class="card-header font-xr text-uppercase bg-yellow border-0"><?php the_title(); ?></h5>
-             <?php endif; ?>
-
-              <div class="card-body bg-light text-center">
-               <?php if($show_link_to_group_page): ?>
-                 <a href="<?php the_permalink(); ?> "class="btn btn-black"><?php _e('Learn more', 'theme-xrnl'); ?></a>
-               <?php endif; ?>
-              </div>
-
-              <div class="card-footer bg-light border-0 text-center">
+               <a href="<?php the_permalink(); ?>"><h5 class="card-header text-center font-xr text-uppercase bg-yellow border-0"><?php the_title(); ?></h5></a>
+               <div class="card-footer bg-xr-yellow border-0 text-center">
                <?php if(get_field('group_twitter_url')): ?>
                  <a href="<?php the_field('group_twitter_url'); ?>"  target="_blank" rel="noreferrer noopener" class="btn twitter" aria-label="twitter"><i class="fab fa-2x fa-twitter"></i></a>
                <?php endif; ?>
@@ -64,8 +58,7 @@ get_header(); ?>
               </div>
 
           </div>
-        </div>
-
+      </div>
       <?php endwhile; wp_reset_query(); ?>
     </div>
 

--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -171,7 +171,7 @@ add_action('init', function(){
     $args = array(
         'label'                 => __( 'Community Group', 'text_domain' ),
         'labels'                => $labels,
-        'supports'              => array( 'title', 'editor' ),
+        'supports'              => array('title', 'editor', 'author', 'revisions'),
         'hierarchical'          => false,
         'public'                => true,
         'show_ui'               => true,

--- a/web/app/themes/xrnl/package.json
+++ b/web/app/themes/xrnl/package.json
@@ -11,7 +11,7 @@
     },
     "devDependencies": {
         "axios": "^0.18",
-        "bootstrap": "~4.3.1",
+        "bootstrap": "4.6.0",
         "cross-env": "^5.1",
         "jquery": "^3.2",
         "laravel-mix": "^4.0.7",
@@ -23,6 +23,5 @@
         "vue": "^2.5.17",
         "vue-template-compiler": "^2.5.21"
     },
-    "dependencies": {
-    }
+    "dependencies": {}
 }

--- a/web/app/themes/xrnl/single-community_group.php
+++ b/web/app/themes/xrnl/single-community_group.php
@@ -6,29 +6,24 @@
 get_header(); ?>
 
 <?php
-$communityPage = apply_filters('wpml_object_id', 6832, 'page', true); // XRNL: 6832 NL, 6853 EN
-$communityPageURL = get_permalink($communityPage);
-$dark_image_overlay = get_field('group_cover_image_darkened');
-$hero_text_color = $dark_image_overlay ? 'white' : 'black';
+  $communityPage = apply_filters('wpml_object_id', 6832, 'page', true); // Page ID: 6832 NL, 6853 EN
+  $communityPageURL = get_permalink($communityPage);
 ?>
 
 <div class="community-group">
+
   <div class="hero-container">
-    <div class="bg-blue px-3 py-lg-5 pb-5 text-center text-<?php echo($hero_text_color) ?> group-cover-image" style="background: <?php if($dark_image_overlay):?> linear-gradient(rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0.45)), <?php endif ?>url('<?php the_field('group_cover_image_url'); ?>'); no-repeat;">
-      <div class="py-5">
-        <h1 class="display-2 text-uppercase font-xr"><?php the_title(); ?></h1>
-      </div>
-    </div>
-    <div class="col-lg-8 mx-auto hero-caption text-<?php echo($hero_text_color); ?>">
+    <img class="group-cover-image mx-auto" src="<?php the_field('group_cover_image_url'); ?>" alt="<?php the_title(); ?>">
+    <div class="hero-caption">
       <?php the_field('group_image_caption'); ?>
     </div>
   </div>
 
   <div class="my-sm-5 my-4">
-    <div class="container py-5 text-center">
+    <div class="container pt-3 pb-5 text-center">
       <div class="row">
         <div class="col-12 col-lg-8 mx-auto">
-            <h1><?php the_title(); ?></h1>
+            <h1 class="display-4"><?php the_title(); ?></h1>
             <p class="text-justify"><?php the_content(); ?></p>
             <h2 class="group-slogan"><?php the_field('group_slogan'); ?></h2>
             <span class="group-social-icons">

--- a/web/app/themes/xrnl/single-community_group.php
+++ b/web/app/themes/xrnl/single-community_group.php
@@ -38,6 +38,54 @@ get_header(); ?>
     </div>
   </div>
 
+  <div class="container py-5 mt-3 text-center">
+    <div class="row">
+      <div class="col-12 col-lg-8 mx-auto picture-gallery">
+        <?php $gallery = get_field('group_picture_gallery'); ?>
+        <?php if (!empty($gallery)) : ?>
+          <?php if(!empty($gallery['heading'])): ?>
+            <h2><?php echo $gallery['heading']; ?></h2>
+          <?php endif; ?>
+          <?php if(!empty($gallery['description'])): ?>
+            <p><?php echo $gallery['description']; ?><p>
+          <?php endif; ?>
+
+          <?php if(is_array($gallery['pictures'])): ?>
+            <div id="cg-carousel" class="carousel slide" data-ride="carousel">
+              <ol class="carousel-indicators my-4">
+                <?php for ($i = 0; $i <= count($gallery['pictures'])-1; $i++) : ?>
+                  <li data-target="#cg-carousel" data-slide-to="<?php echo $i ?>"></li>
+                <?php endfor; ?>
+              </ol>
+
+              <div class="carousel-inner">
+                <?php foreach ($gallery['pictures'] as $picture) : ?>
+                  <div class="carousel-item">
+                    <img class="d-block w-100" src="<?php echo $picture['picture'] ?>" alt="<?php the_field('title'); ?>">
+                    <?php if(!empty($picture['caption'])): ?>
+                      <div class="carousel-caption bg-xr-black mb-4">
+                        <?php echo $picture['caption']; ?>
+                      </div>
+                    <?php endif; ?>
+                  </div>
+                <?php endforeach; ?>
+              </div>
+
+              <a class="carousel-control-prev d-none d-md-flex" href="#cg-carousel" role="button" data-slide="prev">
+                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                <span class="sr-only"><?php _e('Previous', 'theme-xrnl'); ?></span>
+              </a>
+              <a class="carousel-control-next d-none d-md-flex" href="#cg-carousel" role="button" data-slide="next">
+                <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                <span class="sr-only"><?php _e('Next', 'theme-xrnl'); ?></span>
+              </a>
+            </div>
+          <?php endif; ?>
+        <?php endif; ?>
+      </div>
+    </div>
+  </div>
+
   <div class="container pt-3 pb-5 text-center">
     <div class="row">
       <div class="col-12 col-lg-8 mx-auto">
@@ -69,8 +117,18 @@ get_header(); ?>
       </div>
     </div>
   </div>
-  
+
   <a href="<?php echo $communityPageURL ?>" class="btn btn-blue my-4"><i class="fas fa-arrow-left"></i> <?php _e('View all community groups', 'theme-xrnl'); ?></a>
 </div>
+
+<script type="text/javascript">
+  // Initiate the carousel
+  jQuery(document).ready(function($){
+    if ($('.picture-gallery').length) {
+      $('.carousel-item:first').addClass('active');
+      $('.carousel-indicators > li:first').addClass('active');
+    };
+  });
+</script>
 
 <?php get_footer(); ?>

--- a/web/app/themes/xrnl/single-community_group.php
+++ b/web/app/themes/xrnl/single-community_group.php
@@ -11,6 +11,7 @@ get_header(); ?>
 ?>
 
 <div class="community-group">
+  <a href="<?php echo $communityPageURL ?>" class="btn btn-blue my-4"><i class="fas fa-arrow-left"></i> <?php _e('View all community groups', 'theme-xrnl'); ?></a>
 
   <h1 class="display-4 text-center mt-5 mb-3"><?php the_title(); ?></h1>
 
@@ -121,7 +122,6 @@ get_header(); ?>
     </div>
   </div>
 
-  <a href="<?php echo $communityPageURL ?>" class="btn btn-blue my-4"><i class="fas fa-arrow-left"></i> <?php _e('View all community groups', 'theme-xrnl'); ?></a>
 </div>
 
 <script type="text/javascript">

--- a/web/app/themes/xrnl/single-community_group.php
+++ b/web/app/themes/xrnl/single-community_group.php
@@ -12,6 +12,8 @@ get_header(); ?>
 
 <div class="community-group">
 
+  <h1 class="display-4 text-center mt-5 mb-3"><?php the_title(); ?></h1>
+
   <div class="hero-container">
     <img class="group-cover-image mx-auto" src="<?php the_field('group_cover_image_url'); ?>" alt="<?php the_title(); ?>">
     <div class="hero-caption">
@@ -22,14 +24,13 @@ get_header(); ?>
   <div class="container pt-5 text-center">
     <div class="row">
       <div class="col-12 col-lg-8 mx-auto">
-          <h1 class="display-4"><?php the_title(); ?></h1>
-          <div class="text-justify"><?php the_content(); ?></div>
+        <div class="text-justify"><?php the_content(); ?></div>
       </div>
       <div class="col-12 col-lg-8 mx-auto">
         <?php $buttons = get_field('group_link_buttons'); ?>
         <?php if (!empty($buttons)) : ?>
           <?php foreach ($buttons as $button) : ?>
-            <div class=" mt-3">
+            <div class="mt-3">
               <a href="<?php echo $button['target_url'] ?>" class="btn btn-<?php echo $button['colour']; ?>"><?php echo $button['label']; ?></a>
             </div>
           <?php endforeach; ?>

--- a/web/app/themes/xrnl/single-community_group.php
+++ b/web/app/themes/xrnl/single-community_group.php
@@ -42,11 +42,12 @@ get_header(); ?>
             <?php if(get_field('group_youtube_url')): ?>
               <a href="<?php the_field('group_youtube_url'); ?>"  target="_blank" rel="noreferrer noopener" class="btn youtube" aria-label="youtube"><i class="fab fa-2x fa-youtube"></i></a>
             <?php endif; ?>
-
-            <?php if(get_field('group_contact_email')): ?>
-              <a href="mailto:<?php the_field('group_contact_email'); ?>"  target="_blank" rel="noreferrer noopener" class="btn email" aria-label="email"><i class="fas fa-2x fa-envelope"></i></a>
-            <?php endif; ?>
             </span>
+        </div>
+        <div class="col-12 col-lg-8 mx-auto">
+          <?php if(get_field('group_contact_email')): ?>
+            <a href="mailto:<?php the_field('group_contact_email'); ?>"  target="_blank" rel="noreferrer noopener" class="btn email" aria-label="email"><?php the_field('group_contact_email'); ?></a>
+          <?php endif; ?>
         </div>
       </div>
     </div>

--- a/web/app/themes/xrnl/single-community_group.php
+++ b/web/app/themes/xrnl/single-community_group.php
@@ -24,7 +24,9 @@ get_header(); ?>
   <div class="container pt-5 text-center">
     <div class="row">
       <div class="col-12 col-lg-8 mx-auto">
-        <div class="text-justify"><?php the_content(); ?></div>
+        <div class="main-content">
+          <?php the_content(); ?>
+        </div>
       </div>
       <div class="col-12 col-lg-8 mx-auto">
         <?php $buttons = get_field('group_link_buttons'); ?>

--- a/web/app/themes/xrnl/single-community_group.php
+++ b/web/app/themes/xrnl/single-community_group.php
@@ -27,6 +27,10 @@ get_header(); ?>
             <p class="text-justify"><?php the_content(); ?></p>
             <h2 class="group-slogan"><?php the_field('group_slogan'); ?></h2>
             <span class="group-social-icons">
+            <?php if(get_field('group_twitter_url')): ?>
+              <a href="<?php the_field('group_twitter_url'); ?>"  target="_blank" rel="noreferrer noopener" class="btn twitter" aria-label="twitter"><i class="fab  fa-2x fa-twitter"></i></a>
+            <?php endif; ?>
+
             <?php if(get_field('group_facebook_url')): ?>
               <a href="<?php the_field('group_facebook_url'); ?>"  target="_blank" rel="noreferrer noopener" class="btn facebook" aria-label="facebook"><i class="fab  fa-2x fa-facebook-f"></i></a>
             <?php endif; ?>

--- a/web/app/themes/xrnl/single-community_group.php
+++ b/web/app/themes/xrnl/single-community_group.php
@@ -19,39 +19,57 @@ get_header(); ?>
     </div>
   </div>
 
-  <div class="my-sm-5 my-4">
-    <div class="container pt-3 pb-5 text-center">
-      <div class="row">
-        <div class="col-12 col-lg-8 mx-auto">
-            <h1 class="display-4"><?php the_title(); ?></h1>
-            <p class="text-justify"><?php the_content(); ?></p>
-            <h2 class="group-slogan"><?php the_field('group_slogan'); ?></h2>
-            <span class="group-social-icons">
-            <?php if(get_field('group_twitter_url')): ?>
-              <a href="<?php the_field('group_twitter_url'); ?>"  target="_blank" rel="noreferrer noopener" class="btn twitter" aria-label="twitter"><i class="fab  fa-2x fa-twitter"></i></a>
-            <?php endif; ?>
+  <div class="container pt-5 text-center">
+    <div class="row">
+      <div class="col-12 col-lg-8 mx-auto">
+          <h1 class="display-4"><?php the_title(); ?></h1>
+          <div class="text-justify"><?php the_content(); ?></div>
+      </div>
+      <div class="col-12 col-lg-8 mx-auto">
+        <?php $buttons = get_field('group_link_buttons'); ?>
+        <?php if (!empty($buttons)) : ?>
+          <?php foreach ($buttons as $button) : ?>
+            <div class=" mt-3">
+              <a href="<?php echo $button['target_url'] ?>" class="btn btn-<?php echo $button['colour']; ?>"><?php echo $button['label']; ?></a>
+            </div>
+          <?php endforeach; ?>
+        <?php endif; ?>
+      </div>
+    </div>
+  </div>
 
-            <?php if(get_field('group_facebook_url')): ?>
-              <a href="<?php the_field('group_facebook_url'); ?>"  target="_blank" rel="noreferrer noopener" class="btn facebook" aria-label="facebook"><i class="fab  fa-2x fa-facebook-f"></i></a>
-            <?php endif; ?>
-
-            <?php if(get_field('group_instagram_url')): ?>
-              <a href="<?php the_field('group_instagram_url'); ?>"  target="_blank" rel="noreferrer noopener" class="btn instagram" aria-label="instagram"><i class="fab fa-2x fa-instagram"></i></a>
-            <?php endif; ?>
-
-            <?php if(get_field('group_youtube_url')): ?>
-              <a href="<?php the_field('group_youtube_url'); ?>"  target="_blank" rel="noreferrer noopener" class="btn youtube" aria-label="youtube"><i class="fab fa-2x fa-youtube"></i></a>
-            <?php endif; ?>
-            </span>
-        </div>
-        <div class="col-12 col-lg-8 mx-auto">
-          <?php if(get_field('group_contact_email')): ?>
-            <a href="mailto:<?php the_field('group_contact_email'); ?>"  target="_blank" rel="noreferrer noopener" class="btn email" aria-label="email"><?php the_field('group_contact_email'); ?></a>
+  <div class="container pt-3 pb-5 text-center">
+    <div class="row">
+      <div class="col-12 col-lg-8 mx-auto">
+        <h2 class="group-slogan"><?php the_field('group_slogan'); ?></h2>
+        <div class="group-social-icons">
+          <span>
+          <?php if(get_field('group_twitter_url')): ?>
+            <a href="<?php the_field('group_twitter_url'); ?>"  target="_blank" rel="noreferrer noopener" class="btn twitter" aria-label="twitter"><i class="fab  fa-2x fa-twitter"></i></a>
           <?php endif; ?>
+
+          <?php if(get_field('group_facebook_url')): ?>
+            <a href="<?php the_field('group_facebook_url'); ?>"  target="_blank" rel="noreferrer noopener" class="btn facebook" aria-label="facebook"><i class="fab  fa-2x fa-facebook-f"></i></a>
+          <?php endif; ?>
+
+          <?php if(get_field('group_instagram_url')): ?>
+            <a href="<?php the_field('group_instagram_url'); ?>"  target="_blank" rel="noreferrer noopener" class="btn instagram" aria-label="instagram"><i class="fab fa-2x fa-instagram"></i></a>
+          <?php endif; ?>
+
+          <?php if(get_field('group_youtube_url')): ?>
+            <a href="<?php the_field('group_youtube_url'); ?>"  target="_blank" rel="noreferrer noopener" class="btn youtube" aria-label="youtube"><i class="fab fa-2x fa-youtube"></i></a>
+          <?php endif; ?>
+          </span>
+            <div class="col-12 col-lg-8 mx-auto">
+              <?php if(get_field('group_contact_email')): ?>
+                <a href="mailto:<?php the_field('group_contact_email'); ?>"  target="_blank" rel="noreferrer noopener" class="btn email" aria-label="email"><?php the_field('group_contact_email'); ?></a>
+              <?php endif; ?>
+            </div>
         </div>
       </div>
     </div>
   </div>
+  
   <a href="<?php echo $communityPageURL ?>" class="btn btn-blue my-4"><i class="fas fa-arrow-left"></i> <?php _e('View all community groups', 'theme-xrnl'); ?></a>
 </div>
 


### PR DESCRIPTION
This is a bit of a hodgepodge of bugfixes and features for the community group pages. 

1. Added support for `author` and `revision`, so that groups can own their page and track revisions.
2. Added a custom field for twitter.
3. Hero section: currently this doesn't work well because groups use very different photos and graphics. A problem with `background-size: cover` is that some essential parts of images can get cut off on some screen sizes. Another problem is that some groups use text on their cover image, which clashes with the overlaid title.

I've now 
- made the cover image a regular `<img>`, so that it's always shown in full
- removed the overlaid title and increased the size of the main heading underneath

(Some of this is currently done with inline css on some pages 🙀)

4. Added custom fields for optional link buttons below the main content section, for things like downloads or broadcast channels.

5. Made the main content justified for better readability.

6. Added an image gallery, pretty much exactly as on the local group pages. To avoid excessive weight there is a limit of 35 pictures and the maximum file size for one picture is 1.5MB (is that reasonable?)

7. Made some minor improvements on the overview page.
- Better responsive layout, which wasn't always working well. For this I've also upgraded bootstrap from v4.3 to 4.6 because it has better support for responsive cards. (I've checked that this doesn't break anything on other pages.. it's all fine as far as I can tell)
- Removed the redundant "More information" button from cards
- Made the card image clickable


##### To do after deploying (or for testing)
- remove the inline css on the landbouw & zorgprofessionals pages
- fill in the link button fields on the landbouw and families pages


##### Screenshots
![xrnl8_8890_community_xr-nl-families_(iPad Pro)](https://user-images.githubusercontent.com/25393215/112453931-7553d980-8d58-11eb-9763-27193a63fc59.png)

![xrnl8_8890_gemeenschap_(iPad Pro)](https://user-images.githubusercontent.com/25393215/112453982-843a8c00-8d58-11eb-83ea-3f4a36893180.png)

