### PR TITLE
Principles & Values template part and shortcode

### DIFF
--- a/web/app/themes/xrnl/acf-json/group_60a19be777aa5.json
+++ b/web/app/themes/xrnl/acf-json/group_60a19be777aa5.json
@@ -1,0 +1,162 @@
+{
+    "key": "group_60a19be777aa5",
+    "title": "Principles and values",
+    "fields": [
+        {
+            "key": "field_60a19bf73346a",
+            "label": "List of principles and values",
+            "name": "principles_and_values_list",
+            "type": "repeater",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "collapsed": "",
+            "min": 0,
+            "max": 0,
+            "layout": "table",
+            "button_label": "Add P&Vs",
+            "sub_fields": [
+                {
+                    "key": "field_60a1a0dcf0c35",
+                    "label": "Principle or value",
+                    "name": "principle_or_value",
+                    "type": "group",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "layout": "block",
+                    "wpml_cf_preferences": 0,
+                    "sub_fields": [
+                        {
+                            "key": "field_60a1a104f0c36",
+                            "label": "Bold text",
+                            "name": "bold_text",
+                            "type": "text",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "wpml_cf_preferences": 0,
+                            "default_value": "",
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "",
+                            "maxlength": ""
+                        },
+                        {
+                            "key": "field_60a1a110f0c37",
+                            "label": "Regular text",
+                            "name": "regular_text",
+                            "type": "text",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "wpml_cf_preferences": 0,
+                            "default_value": "",
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "",
+                            "maxlength": ""
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "key": "field_60a1a09534859",
+            "label": "Demand (copy)",
+            "name": "demand_copy",
+            "type": "group",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "layout": "block",
+            "sub_fields": [
+                {
+                    "key": "field_60a1a0953485a",
+                    "label": "Bold text",
+                    "name": "bold_text",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 2,
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                },
+                {
+                    "key": "field_60a1a0953485b",
+                    "label": "Regular text",
+                    "name": "regular_text",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 2,
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                }
+            ]
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "options_page",
+                "operator": "==",
+                "value": "acf-options-editorial"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "modified": 1621205279
+}

--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -964,3 +964,11 @@ if( function_exists('acf_add_options_page') ) {
   ));
 
 }
+
+function xrnl_pv_shortcode()
+{
+  ob_start();
+  get_template_part('template-parts/principles-and-values');
+  return ob_get_clean(); 
+}
+add_shortcode('xrnl-principles-and-values', 'xrnl_pv_shortcode');

--- a/web/app/themes/xrnl/template-parts/principles-and-values.php
+++ b/web/app/themes/xrnl/template-parts/principles-and-values.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * The template part for displaying the Principles & Values
+ */
+?>
+
+<?php if( have_rows('xrnl_demands_list', 'option') ): ?>
+    <ol class="pl-3 counter mt-3">
+    <?php while( have_rows('principles_and_values_list', 'option') ): the_row(); ?>
+        <?php $pv = get_sub_field('principle_or_value'); ?>
+        <li class="pl-4">
+            <div class="text-green font-xr">
+            <?php echo $pv['bold_text']; ?>
+            </div>
+            <span>
+            <?php echo $pv['regular_text']; ?>
+            </span>
+        </li>
+    <?php endwhile; ?>
+    </ol>
+<?php endif; ?>


### PR DESCRIPTION
[For this Trello card](https://trello.com/c/dObMIu0J/293-direct-link-to-principles-and-values-on-website).

This PR includes a template-part for the Principles and Values list, similar to the Demands list.
Like for the Demands list, custom fields show up in the XRNL Settings > Editorial tab.

It also provides a shortcode for the P&V list, so that they can be embedded easily on any page by inserting `[xrnl_principles_and_values]`.


#### CFs in the XRNL Settings tab
<img width="807" alt="image" src="https://user-images.githubusercontent.com/25393215/118416216-d4760080-b6ae-11eb-9e64-8ff25ac19bf4.png">

#### Shortcode instead of html in the about-us page
<img width="794" alt="image" src="https://user-images.githubusercontent.com/25393215/118416236-f66f8300-b6ae-11eb-81ad-15e895f92d3d.png">


