### PR TITLE
Check that the image field is not empty in local groups/ actions

### DIFF
--- a/web/app/themes/xrnl/single-xrnl_local_group.php
+++ b/web/app/themes/xrnl/single-xrnl_local_group.php
@@ -257,7 +257,7 @@
                 <div class="action-item">
                   <h5 class="action-item-title"><?php echo($action['title']); ?></h5>
                   <div class="action-item-desc"><?php echo($action['description']); ?></div>
-                  <?php if (isset($action['picture_url'])) : ?>
+                  <?php if (!empty($action['picture_url'])) : ?>
                     <img src="<?php echo($action['picture_url']); ?>" alt="Extinction Rebellion <?php the_field('group_name'); ?>">
                   <?php endif; ?>
                 </div>


### PR DESCRIPTION
Quick bugfix for the local group pages / actions tab, where actions without an image still have an `img` element underneath, and the alt text of that non-existing image gets displayed in an unsightly box in many browsers. 

Actions without an image should simply have no `img` element. 

There was already a check for this but it wasn't working properly; replacing `isset` with `!empty` fixes it.
