### PR TITLE
disable Matomo cookies

### DIFF
--- a/web/app/themes/xrnl/header.php
+++ b/web/app/themes/xrnl/header.php
@@ -13,8 +13,9 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous" />
     <!-- Matomo -->
     <script type="text/javascript">
-      var _paq = window._paq || [];
+      var _paq = window._paq = window._paq || [];
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["disableCookies"]);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {
@@ -22,7 +23,7 @@
         _paq.push(['setTrackerUrl', u+'matomo.php']);
         _paq.push(['setSiteId', '1']);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+        g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
       })();
     </script>
     <!-- End Matomo Code -->


### PR DESCRIPTION
I've disabled the cookies from Matomo as described by Fleur in [this task](https://trello.com/c/ldGuw5Gu)

I got this new tracking code by going to the [tracking code page](https://extinctionrebellion.nl/matomo/index.php?module=CoreAdminHome&action=trackingCodeGenerator&idSite=1&period=day&date=yesterday&idContainer=78IMS3NI) of Matomo, click on "advance options", click on "disable tracking cookies" and copy pasting the new tracking code.