### PR TITLE
Action Network form improvements

### DIFF
--- a/web/app/themes/xrnl/assets/sass/form.scss
+++ b/web/app/themes/xrnl/assets/sass/form.scss
@@ -25,17 +25,6 @@
     color: #000 !important;
   }
 
-  #can_embed_form form {
-    input,
-    select {
-      &:focus,
-      &:active {
-        // we use a pink bg, so make the box shadow dark pink
-        box-shadow: 0 0 0.2rem 0.2rem rgba(163, 33, 167, 0.25);
-      }
-    }
-  }
-
   h2 {
     font-family: $brand-font-secondary;
     text-transform: none;

--- a/web/app/themes/xrnl/assets/sass/form.scss
+++ b/web/app/themes/xrnl/assets/sass/form.scss
@@ -57,12 +57,6 @@
       @extend .form-group;
     }
 
-    // hide form labels with texts
-    label.control-label,
-    label.floatlabel-label {
-      display: none !important;
-    }
-
     // display checkboxes
     label.checkbox {
       display: block;

--- a/web/app/themes/xrnl/assets/sass/form.scss
+++ b/web/app/themes/xrnl/assets/sass/form.scss
@@ -15,6 +15,27 @@
     display: none;
   }
 
+  #can_embed_form_inner > h2 {
+    display: none;
+  }
+
+  #can_thank_you {
+    background-color: transparent !important;
+    text-align: center !important;
+    color: #000 !important;
+  }
+
+  #can_embed_form form {
+    input,
+    select {
+      &:focus,
+      &:active {
+        // we use a pink bg, so make the box shadow dark pink
+        box-shadow: 0 0 0.2rem 0.2rem rgba(163, 33, 167, 0.25);
+      }
+    }
+  }
+
   h2 {
     font-family: $brand-font-secondary;
     text-transform: none;

--- a/web/app/themes/xrnl/assets/sass/form.scss
+++ b/web/app/themes/xrnl/assets/sass/form.scss
@@ -32,6 +32,14 @@
     margin-bottom: 0 !important;
   }
 
+  label.control-label {
+    font-size: 80%;
+    font-family: $brand-font-secondary;
+    text-transform: none;
+    margin-bottom: 0.5rem;
+    letter-spacing: 0px;
+  }
+
   form {
     @extend .row;
     width: auto !important;
@@ -95,7 +103,7 @@
     #d_sharing li,
     .controls.check_radio_field {
       label {
-        font-size: 90% !important;
+        font-size: 80%;
         input {
           width: 15px;
           height: 15px;

--- a/web/app/themes/xrnl/assets/sass/form.scss
+++ b/web/app/themes/xrnl/assets/sass/form.scss
@@ -1,62 +1,49 @@
 /* Action Network Form */
 
-$default-spacing: 0.75rem;
-$default-font-size: 1rem;
+$spacing-form-fields: 0.75rem;
+$font-size-form-fields: 1rem;
 
-@mixin reset-text() {
-  font-size: inherit !important;
-  line-height: inherit !important;
-}
-
+// main container of the Action Network form
 #can_embed_form {
-  h4,
+  /*
+   * Code section that hides unnecessary elements
+   */
+
+  // hide all form meta-information (everything that isn't a form field or the submit button)
+  #can_embed_form_inner > {
+    h2,
+    h4,
+    #logo_wrap {
+      // Action Network logo
+      display: none;
+    }
+  }
+  // hide unnecessary text: action sponsored by XR NL
   #action_info {
     display: none;
   }
-
-  #logo_wrap {
+  // hide redundant country dropdown as the country will always be NL
+  .country_drop_wrap {
+    display: none !important;
+  }
+  // hide default opt-in checkbox because we use radio buttons with custom text
+  form #d_sharing {
     display: none;
   }
 
-  #can_embed_form_inner > h2 {
-    display: none;
-  }
-
-  #can_thank_you {
-    background-color: transparent !important;
-    text-align: center !important;
-    color: #000 !important;
-  }
-
-  h2 {
-    font-family: $brand-font-secondary;
-    text-transform: none;
-    border: 0 !important;
-    margin-bottom: 0 !important;
-  }
-
-  // style for all text labels
-  label.control-label {
-    font-size: $default-font-size;
-    font-family: $brand-font-secondary;
-    text-transform: none;
-    margin-bottom: $default-spacing;
-    padding: 0 $default-spacing;
-    letter-spacing: 0px;
-  }
-
-  // override margin for input elements
-  .floatlabel-wrapper {
-    @extend .form-group;
-    margin-bottom: $default-spacing;
-  }
-
+  /*
+   * Code section that styles form components
+   *
+   * Unfortunately the html that comes out of actionnetwork is not
+   * customizable at all. Hence a lot of css customization here! :(
+   */
   form {
+    /*
+     * Code section for generic styles
+     */
     @extend .row;
     width: auto !important;
 
-    // Unfortunately the html that comes out of actionnetwork is not
-    // customizable at all. Hence a lot of css customization here! :(
     #form_col1,
     #form_col2 {
       @extend .col-12;
@@ -82,33 +69,44 @@ $default-font-size: 1rem;
       margin: 0;
     }
 
-    // display checkboxes
-    label.checkbox {
-      display: block;
-      @extend .my-2;
-    }
-
-    // bootstrap styling for forms
+    /*
+     * Code section for custom styling of form elements
+     */
     input,
     select,
     textarea {
-      @extend .form-control;
-      margin-bottom: $default-spacing;
+      @extend .form-control; // use bootstrap style
+      margin-bottom: $spacing-form-fields;
 
       // validation feedback
       &.error_input {
-        @extend .is-invalid;
+        @extend .is-invalid; // use bootstrap style
         &:focus {
           box-shadow: none;
         }
       }
     }
 
+    // override styles for container of text input elements
+    .floatlabel-wrapper {
+      margin-bottom: $spacing-form-fields;
+    }
+
+    // style for all text labels
+    label.control-label {
+      font-size: $font-size-form-fields;
+      font-family: $brand-font-secondary;
+      text-transform: none;
+      margin-bottom: $spacing-form-fields;
+      padding: 0 $spacing-form-fields;
+      letter-spacing: 0px;
+    }
+
     // checkboxes & radio buttons
     #d_sharing li,
     .controls.check_radio_field {
       label {
-        font-size: $default-font-size;
+        font-size: $font-size-form-fields;
         input {
           width: 15px;
           height: 15px;
@@ -118,19 +116,13 @@ $default-font-size: 1rem;
 
     // Select box
     select {
-      font-size: $default-font-size;
-    }
-    .country_drop_wrap select.can_select {
-      height: 44px !important;
-    }
-    span.can_select {
-      display: none !important;
+      font-size: $font-size-form-fields;
     }
     .select2-container {
-      margin-bottom: $default-spacing;
+      margin-bottom: $spacing-form-fields;
     }
     .select2-chosen {
-      font-size: $default-font-size;
+      font-size: $font-size-form-fields;
     }
 
     // submit button
@@ -140,37 +132,27 @@ $default-font-size: 1rem;
       @extend .btn-black;
       @extend .btn-lg;
     }
-
-    // Misc overrides
-    #d_sharing {
-      display: none;
-    }
   }
 
-  @include reset-text();
-
-  // Styling Thank you section after submission
-  // Keep it simple, let's not distract the user even more,
-  // let them browse the site
-  & > .clearfix {
-    display: none;
-  }
+  /*
+   * Code section for the thank you content that shows when a user submits the form
+   * The content of this text is configured from Action Network
+   */
 
   & > #can_thank_you {
     @extend .mt-4;
     @extend .mb-3;
     background-color: transparent !important;
-    padding: 0 !important;
-    text-align: left !important;
-
+    color: #000 !important;
     h1 {
+      text-align: center !important;
       @extend .h3;
       @extend .font-xr;
       @extend .text-uppercase;
     }
-
-    p {
-      @include reset-text();
+    #action_thank_you_text > p {
+      font-size: 1.4rem;
+      font-family: $brand-font-secondary;
     }
   }
 }

--- a/web/app/themes/xrnl/assets/sass/form.scss
+++ b/web/app/themes/xrnl/assets/sass/form.scss
@@ -1,5 +1,8 @@
 /* Action Network Form */
 
+$default-spacing: 0.75rem;
+$default-font-size: 1rem;
+
 @mixin reset-text() {
   font-size: inherit !important;
   line-height: inherit !important;
@@ -32,12 +35,20 @@
     margin-bottom: 0 !important;
   }
 
+  // style for all text labels
   label.control-label {
-    font-size: 80%;
+    font-size: $default-font-size;
     font-family: $brand-font-secondary;
     text-transform: none;
-    margin-bottom: 0.5rem;
+    margin-bottom: $default-spacing;
+    padding: 0 $default-spacing;
     letter-spacing: 0px;
+  }
+
+  // override margin for input elements
+  .floatlabel-wrapper {
+    @extend .form-group;
+    margin-bottom: $default-spacing;
   }
 
   form {
@@ -71,10 +82,6 @@
       margin: 0;
     }
 
-    .floatlabel-wrapper {
-      @extend .form-group;
-    }
-
     // display checkboxes
     label.checkbox {
       display: block;
@@ -82,13 +89,11 @@
     }
 
     // bootstrap styling for forms
-    input[type="text"],
-    input[type="email"],
-    input[type="number"],
+    input,
     select,
     textarea {
       @extend .form-control;
-      border: 0;
+      margin-bottom: $default-spacing;
 
       // validation feedback
       &.error_input {
@@ -103,7 +108,7 @@
     #d_sharing li,
     .controls.check_radio_field {
       label {
-        font-size: 80%;
+        font-size: $default-font-size;
         input {
           width: 15px;
           height: 15px;
@@ -113,17 +118,19 @@
 
     // Select box
     select {
-      opacity: 1 !important;
-      position: static !important;
-      font-size: 1rem !important;
-      @extend .form-control;
-      border-color: white !important;
+      font-size: $default-font-size;
     }
     .country_drop_wrap select.can_select {
       height: 44px !important;
     }
     span.can_select {
       display: none !important;
+    }
+    .select2-container {
+      margin-bottom: $default-spacing;
+    }
+    .select2-chosen {
+      font-size: $default-font-size;
     }
 
     // submit button
@@ -132,7 +139,6 @@
       @extend .btn;
       @extend .btn-black;
       @extend .btn-lg;
-      @extend .my-3;
     }
 
     // Misc overrides

--- a/web/app/themes/xrnl/assets/sass/form.scss
+++ b/web/app/themes/xrnl/assets/sass/form.scss
@@ -91,25 +91,15 @@
       }
     }
 
-    // checkboxes
+    // checkboxes & radio buttons
     #d_sharing li,
     .controls.check_radio_field {
-      @extend .form-check;
       label {
-        @extend .form-check-label;
         font-size: 90% !important;
-        padding: 0px 0 0 8px !important;
-        line-height: inherit !important;
-        input[type="checkbox"] {
-          @extend .form-check-input;
-          width: 20px;
-          height: 20px;
+        input {
+          width: 15px;
+          height: 15px;
         }
-      }
-    }
-    .controls.check_radio_field {
-      label {
-        padding: 6px 0 0 8px !important;
       }
     }
 

--- a/web/app/themes/xrnl/assets/sass/form.scss
+++ b/web/app/themes/xrnl/assets/sass/form.scss
@@ -64,9 +64,9 @@
     }
 
     // bootstrap styling for forms
-    input[type=text],
-    input[type=email],
-    input[type=number],
+    input[type="text"],
+    input[type="email"],
+    input[type="number"],
     select,
     textarea {
       @extend .form-control;
@@ -90,7 +90,7 @@
         font-size: 90% !important;
         padding: 0px 0 0 8px !important;
         line-height: inherit !important;
-        input[type=checkbox] {
+        input[type="checkbox"] {
           @extend .form-check-input;
           width: 20px;
           height: 20px;
@@ -119,7 +119,7 @@
     }
 
     // submit button
-    input[type=submit] {
+    input[type="submit"] {
       @extend .btn-block;
       @extend .btn;
       @extend .btn-black;
@@ -138,11 +138,11 @@
   // Styling Thank you section after submission
   // Keep it simple, let's not distract the user even more,
   // let them browse the site
-  &> .clearfix {
+  & > .clearfix {
     display: none;
   }
 
-  &> #can_thank_you {
+  & > #can_thank_you {
     @extend .mt-4;
     @extend .mb-3;
     background-color: transparent !important;

--- a/web/app/themes/xrnl/assets/sass/join.scss
+++ b/web/app/themes/xrnl/assets/sass/join.scss
@@ -1,4 +1,3 @@
-
 .join {
   font-size: 1.4rem;
   .join-cover-image {
@@ -13,25 +12,6 @@
 
   .join-location {
     font-size: 1.6rem;
-  }
-
-  #can_embed_form_inner > h2 {
-    display: none;
-  }
-  #can_embed_form #can_thank_you {
-    background-color: transparent !important;
-    text-align: center !important;
-    color: #000 !important;
-  }
-
-  #can_embed_form form {
-    input, select {
-      &:focus,
-      &:active {
-        // we use a pink bg, so make the box shadow dark pink
-        box-shadow: 0 0 0.2rem 0.2rem rgba(163, 33, 167, 0.25);
-      }
-    }
   }
 
   .do-more-actions {

--- a/web/app/themes/xrnl/assets/sass/petition.scss
+++ b/web/app/themes/xrnl/assets/sass/petition.scss
@@ -8,10 +8,6 @@
     padding: 4rem 0.2rem;
   }
 
-  #can_embed_form_inner > h2 {
-    display: none;
-  }
-
   .isInvisible {
     // necessary for it to occupy 0 space in the page
     display: none;

--- a/web/app/themes/xrnl/assets/sass/rwb.scss
+++ b/web/app/themes/xrnl/assets/sass/rwb.scss
@@ -1,4 +1,3 @@
-
 .rwb {
   font-size: 1.4rem;
   .rwb-cover-image {
@@ -8,25 +7,5 @@
 
   .rwb-location {
     font-size: 1.6rem;
-  }
-
-  #can_embed_form_inner > h2 {
-    display: none;
-  }
-
-  #can_embed_form #can_thank_you {
-    background-color: transparent !important;
-    text-align: center !important;
-    color: #000 !important;
-  }
-
-  #can_embed_form form {
-    input, select {
-      &:focus,
-      &:active {
-        // we use a pink bg, so make the box shadow dark pink
-        box-shadow: 0 0 0.2rem 0.2rem rgba(163, 33, 167, 0.25);
-      }
-    }
   }
 }


### PR DESCRIPTION
The main purpose of this change is to:

1. [adding an opt-in](https://trello.com/c/WplmXcny), so people give explicit consent for getting contacted by XR
2. [showing the field labels](https://trello.com/c/SDEqWeJ2), so people know why we ask certain data (such as phone number and municipality.

Of course, when working on this I got frustrated by the inconsistent styles so I also changed them so that there is consistent font-type, font-size, margins and paddings.

Also I removed all redundant code from this `scss` file, and documented and organised the file so that we better understand what the effect is of all that custom css.

Note that if you test this locally you won't see the opt-in option. I need to add that to the Action Network form after we deploy the new css

## Image previews

Here is how the form looks, before and after the css changes

### form with old css (before submission)

![image](https://user-images.githubusercontent.com/15846595/124619721-2ea66d00-de79-11eb-99d9-5c9b68430ae0.png)

![Screenshot from 2021-07-06 15-38-50](https://user-images.githubusercontent.com/15846595/124619827-44b42d80-de79-11eb-8d34-48cffbc703e1.png)

### form with new css (before submission)

desktop:

![Screenshot from 2021-07-06 13-59-23](https://user-images.githubusercontent.com/15846595/124618787-61039a80-de78-11eb-945e-6283deb48eaf.png)

mobile:

![Screen Shot 2021-07-06 at 13 59 45](https://user-images.githubusercontent.com/15846595/124618819-67921200-de78-11eb-94e4-3c70b233c798.png)

### form with new css (after submission)

![Screenshot from 2021-07-06 13-54-09](https://user-images.githubusercontent.com/15846595/124619003-90b2a280-de78-11eb-9aff-c6b1ca592db4.png)