### PR TITLE
Disable users API endpoint

### DIFF
--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -982,3 +982,18 @@ function register_button_click($button_identifier, $page_identifier = NULL)
   $onclick = "_paq.push(['trackEvent', 'Button', 'Clicked', '" . $page_identifier . " - ". $button_identifier . "']);";
   return $onclick;
 }
+
+/**
+ * Disable the `users` endpoint from the REST API
+ * because it exposes usernames
+ */
+function xrnl_disable_rest_endpoints ($endpoints) {
+  if (isset($endpoints['/wp/v2/users'])) {
+      unset($endpoints['/wp/v2/users']);
+  }
+  if (isset($endpoints['/wp/v2/users/(?P<id>[\d]+)'])) {
+      unset($endpoints['/wp/v2/users/(?P<id>[\d]+)']);
+  }
+  return $endpoints;
+}
+add_filter('rest_endpoints', 'xrnl_disable_rest_endpoints');


### PR DESCRIPTION
This disables the `users` endpoint from the REST API in order to prevent Wordpress from exposing usernames. See [this trello task](https://trello.com/c/v8y2OLuM/287-wordpress-exposing-usernames).