### PR TITLE
How we work template & custom fields

### DIFF
--- a/web/app/themes/xrnl/acf-json/group_6060f0baa2615.json
+++ b/web/app/themes/xrnl/acf-json/group_6060f0baa2615.json
@@ -15,6 +15,7 @@
                 "class": "",
                 "id": ""
             },
+            "wpml_cf_preferences": 2,
             "default_value": "",
             "placeholder": "",
             "prepend": "",
@@ -34,10 +35,10 @@
                 "class": "",
                 "id": ""
             },
+            "wpml_cf_preferences": 2,
             "default_value": "",
             "tabs": "text",
             "media_upload": 0,
-            "wpml_cf_preferences": 0,
             "toolbar": "full",
             "delay": 0
         },
@@ -54,12 +55,12 @@
                 "class": "",
                 "id": ""
             },
+            "wpml_cf_preferences": 2,
             "collapsed": "",
             "min": 0,
             "max": 0,
-            "layout": "table",
+            "layout": "block",
             "button_label": "",
-            "wpml_cf_preferences": 0,
             "sub_fields": [
                 {
                     "key": "field_606217bb98a04",
@@ -74,10 +75,11 @@
                         "class": "",
                         "id": ""
                     },
+                    "wpml_cf_preferences": 2,
                     "default_value": "",
                     "placeholder": "Title of the working group: Outreach & Training, Tech...",
                     "maxlength": "",
-                    "rows": "",
+                    "rows": 1,
                     "new_lines": ""
                 },
                 {
@@ -93,10 +95,11 @@
                         "class": "",
                         "id": ""
                     },
+                    "wpml_cf_preferences": 2,
                     "default_value": "Enter some information about the working group...",
-                    "tabs": "text",
-                    "media_upload": 0,
+                    "tabs": "all",
                     "toolbar": "full",
+                    "media_upload": 0,
                     "delay": 0
                 },
                 {
@@ -112,6 +115,7 @@
                         "class": "",
                         "id": ""
                     },
+                    "wpml_cf_preferences": 2,
                     "collapsed": "",
                     "min": 0,
                     "max": 0,
@@ -131,6 +135,7 @@
                                 "class": "",
                                 "id": ""
                             },
+                            "wpml_cf_preferences": 2,
                             "default_value": "",
                             "placeholder": "",
                             "prepend": "",
@@ -150,6 +155,7 @@
                                 "class": "",
                                 "id": ""
                             },
+                            "wpml_cf_preferences": 3,
                             "default_value": "",
                             "placeholder": ""
                         }
@@ -173,7 +179,7 @@
     "label_placement": "top",
     "instruction_placement": "label",
     "hide_on_screen": "",
-    "active": 1,
+    "active": true,
     "description": "",
-    "modified": 1620503343
+    "modified": 1627646290
 }

--- a/web/app/themes/xrnl/acf-json/group_6103d882da0fa.json
+++ b/web/app/themes/xrnl/acf-json/group_6103d882da0fa.json
@@ -39,7 +39,7 @@
                     "default_value": "",
                     "placeholder": "",
                     "maxlength": "",
-                    "rows": "",
+                    "rows": 1,
                     "new_lines": ""
                 },
                 {
@@ -141,5 +141,5 @@
     "hide_on_screen": "",
     "active": true,
     "description": "",
-    "modified": 1627646069
+    "modified": 1627646194
 }

--- a/web/app/themes/xrnl/acf-json/group_6103d882da0fa.json
+++ b/web/app/themes/xrnl/acf-json/group_6103d882da0fa.json
@@ -1,0 +1,145 @@
+{
+    "key": "group_6103d882da0fa",
+    "title": "How we work",
+    "fields": [
+        {
+            "key": "field_6103d882e3927",
+            "label": "Foldout sections",
+            "name": "sections",
+            "type": "repeater",
+            "instructions": "List of fold-out menus that users can click to read more information",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 2,
+            "collapsed": "",
+            "min": 0,
+            "max": 0,
+            "layout": "block",
+            "button_label": "",
+            "sub_fields": [
+                {
+                    "key": "field_6103d882eb70c",
+                    "label": "Title",
+                    "name": "title",
+                    "type": "textarea",
+                    "instructions": "Title that appears on the foldout menu that users click",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 2,
+                    "default_value": "",
+                    "placeholder": "",
+                    "maxlength": "",
+                    "rows": "",
+                    "new_lines": ""
+                },
+                {
+                    "key": "field_6103d882eb777",
+                    "label": "Text",
+                    "name": "text",
+                    "type": "wysiwyg",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 2,
+                    "default_value": "",
+                    "tabs": "all",
+                    "toolbar": "full",
+                    "media_upload": 0,
+                    "delay": 0
+                },
+                {
+                    "key": "field_6103d882eb7e2",
+                    "label": "Links",
+                    "name": "links",
+                    "type": "repeater",
+                    "instructions": "Here you can add any number of buttons that link to other places where users can read more information",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 2,
+                    "collapsed": "",
+                    "min": 0,
+                    "max": 0,
+                    "layout": "table",
+                    "button_label": "",
+                    "sub_fields": [
+                        {
+                            "key": "field_6103d88315938",
+                            "label": "Label",
+                            "name": "label",
+                            "type": "text",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "wpml_cf_preferences": 2,
+                            "default_value": "",
+                            "placeholder": "",
+                            "prepend": "",
+                            "append": "",
+                            "maxlength": ""
+                        },
+                        {
+                            "key": "field_6103d883159a3",
+                            "label": "Link",
+                            "name": "link",
+                            "type": "url",
+                            "instructions": "",
+                            "required": 0,
+                            "conditional_logic": 0,
+                            "wrapper": {
+                                "width": "",
+                                "class": "",
+                                "id": ""
+                            },
+                            "wpml_cf_preferences": 3,
+                            "default_value": "",
+                            "placeholder": ""
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "page_template",
+                "operator": "==",
+                "value": "how_we_work.php"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "modified": 1627646069
+}

--- a/web/app/themes/xrnl/functions.php
+++ b/web/app/themes/xrnl/functions.php
@@ -942,11 +942,13 @@ if( function_exists('acf_add_options_page') ) {
 }
 
 /*
- * Function replaces ' & ' and spaces to '-' so that
+ * Function replaces some special characters so that
  * string can be used as an ID on a HTML element.
  */
 function formatElementID($str) {
-    return strtolower(str_replace(array(', ', ' & ', ' '), '-', $str));
+    $str = str_replace(array('?', ':', ','), '', $str);
+    $str = str_replace(array(' & ',' '), '-', $str);
+    return strtolower($str);
 }
 
 function xrnl_pv_shortcode()

--- a/web/app/themes/xrnl/how_we_work.php
+++ b/web/app/themes/xrnl/how_we_work.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Template name: How we work
+ */
+
+get_header(); ?>
+
+<main>
+  <div class="container py-5">
+    <div class="row">
+      <div class="col-12 mb-5 text-justify">
+        <header class="entry-header">
+          <h1 class="entry-title"><?php the_title(); ?></h1>
+        </header>
+        <?php the_content(); ?>
+      </div>
+    </div>
+
+        <div class="row">
+    <?php if (have_rows('sections')) : ?>
+      <div class="col-12 mb-5 text-justify">
+          <?php while (have_rows('sections')) {
+            the_row();
+            $groupId = formatElementID(get_sub_field('title'));
+          ?>
+            <div class="col-12 py-2">
+              <div id="<?php echo "section-" . formatElementID(get_sub_field('title')); ?>" class="mx-auto">
+                <a class="btn btn-yellow btn-lg btn-block text-left" data-toggle="collapse" href="#<?php echo $groupId; ?>" role="button" aria-expanded="false" aria-controls="<?php echo $groupId; ?>">
+                  <?php the_sub_field('title') ?>
+                  <i class="fas fa-chevron-down float-right pt-1"></i>
+                </a>
+                <div class="text-left collapse pt-2" id="<?php echo $groupId; ?>">
+                  <div class="pt-3 text-justify">
+                    <?php the_sub_field('text'); ?>
+                  </div>
+                  <div class="pt-3 text-justify">
+                    <?php if (have_rows('links')) : ?>
+                      <?php while (have_rows('links')) {
+                        the_row(); ?>
+                        <a class="btn btn-lg btn-black" href="<?php the_sub_field('link'); ?>"><?php the_sub_field('label'); ?></a>
+                      <?php } ?>
+                    <?php endif; ?>
+                  </div>
+                </div>
+              </div>
+            </div>
+          <?php } ?>
+        </div>
+    <?php endif; ?>
+      </div>
+  </div>
+</main>
+
+<?php get_footer(); ?>

--- a/web/app/themes/xrnl/how_we_work.php
+++ b/web/app/themes/xrnl/how_we_work.php
@@ -17,9 +17,9 @@ get_header(); ?>
       </div>
     </div>
 
-        <div class="row">
-    <?php if (have_rows('sections')) : ?>
-      <div class="col-12 mb-5 text-justify">
+    <div class="row">
+      <?php if (have_rows('sections')) : ?>
+        <div class="col-12 mb-5 text-justify">
           <?php while (have_rows('sections')) {
             the_row();
             $sectionId = formatElementID(get_sub_field('title'));
@@ -48,8 +48,8 @@ get_header(); ?>
             </div>
           <?php } ?>
         </div>
-    <?php endif; ?>
-      </div>
+      <?php endif; ?>
+    </div>
   </div>
 </main>
 

--- a/web/app/themes/xrnl/how_we_work.php
+++ b/web/app/themes/xrnl/how_we_work.php
@@ -22,15 +22,16 @@ get_header(); ?>
       <div class="col-12 mb-5 text-justify">
           <?php while (have_rows('sections')) {
             the_row();
-            $groupId = formatElementID(get_sub_field('title'));
+            $sectionId = formatElementID(get_sub_field('title'));
+            $sectionTextId = $sectionId . "-text";
           ?>
             <div class="col-12 py-2">
-              <div id="<?php echo "section-" . formatElementID(get_sub_field('title')); ?>" class="mx-auto">
-                <a class="btn btn-yellow btn-lg btn-block text-left" data-toggle="collapse" href="#<?php echo $groupId; ?>" role="button" aria-expanded="false" aria-controls="<?php echo $groupId; ?>">
+              <div id="<?php echo $sectionId ?>" class="mx-auto">
+                <a class="btn btn-yellow btn-lg btn-block text-left" data-toggle="collapse" href="#<?php echo $sectionTextId; ?>" role="button" aria-expanded="false" aria-controls="<?php echo $sectionTextId; ?>">
                   <?php the_sub_field('title') ?>
                   <i class="fas fa-chevron-down float-right pt-1"></i>
                 </a>
-                <div class="text-left collapse pt-2" id="<?php echo $groupId; ?>">
+                <div class="text-left collapse pt-2" id="<?php echo $sectionTextId; ?>">
                   <div class="pt-3 text-justify">
                     <?php the_sub_field('text'); ?>
                   </div>

--- a/web/app/themes/xrnl/structure_circles.php
+++ b/web/app/themes/xrnl/structure_circles.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Template name: Structure - Circles
  */
@@ -8,45 +9,46 @@ get_header(); ?>
 <main class="structure-circles">
   <div class="container py-5">
     <div class="col-lg-12 mb-5 text-justify">
-        <header class="entry-header">
-                <h1 class="entry-title"><?php the_title(); ?></h1>
-        </header>
+      <header class="entry-header">
+        <h1 class="entry-title"><?php the_title(); ?></h1>
+      </header>
       <?php the_content(); ?>
     </div>
 
-    <?php if( have_rows('circles') ): ?>
-        <div class="col-lg-12 mb-5 text-justify">
-            <h1 class="font-xr" id="working-groups"><?php the_field('title') ?></h1>
-            <?php the_field('introduction') ?>
-            <div class="row">
-              <?php while ( have_rows('circles') ){ the_row();
+    <?php if (have_rows('circles')) : ?>
+      <div class="col-lg-12 mb-5 text-justify">
+        <h1 class="font-xr" id="working-groups"><?php the_field('title') ?></h1>
+        <?php the_field('introduction') ?>
+        <div class="row">
+          <?php while (have_rows('circles')) {
+            the_row();
             $sectionId = formatElementID(get_sub_field('title'));
             $sectionTextId = $sectionId . "-text";
-            ?>
-              <div class="col-12 py-2">
-                <div id="<?php echo $sectionId; ?>" class="mx-auto">
-                  <a class="btn btn-yellow btn-lg btn-block text-left" data-toggle="collapse" href="#<?php echo $sectionTextId; ?>"
-                    role="button" aria-expanded="false" aria-controls="<?php echo $sectionTextId; ?>">
-                    <?php the_sub_field('title') ?>
-                    <i class="fas fa-chevron-down float-right pt-1"></i>
-                  </a>
-                  <div class="text-left collapse pt-2" id="<?php echo $sectionTextId; ?>">
-                    <div class="pt-3 text-justify">
-                        <?php the_sub_field('description'); ?>
-                    </div>
-                    <div class="pt-3 text-justify">
-                        <?php if (have_rows('links')) : ?>
-                          <?php while ( have_rows('links') ){ the_row(); ?>
-                            <a class="btn btn-lg btn-black" href="<?php the_sub_field('link'); ?>"><?php the_sub_field('label'); ?></a>
-                          <?php } ?>
-                        <?php endif; ?>
-                    </div>
+          ?>
+            <div class="col-12 py-2">
+              <div id="<?php echo $sectionId; ?>" class="mx-auto">
+                <a class="btn btn-yellow btn-lg btn-block text-left" data-toggle="collapse" href="#<?php echo $sectionTextId; ?>" role="button" aria-expanded="false" aria-controls="<?php echo $sectionTextId; ?>">
+                  <?php the_sub_field('title') ?>
+                  <i class="fas fa-chevron-down float-right pt-1"></i>
+                </a>
+                <div class="text-left collapse pt-2" id="<?php echo $sectionTextId; ?>">
+                  <div class="pt-3 text-justify">
+                    <?php the_sub_field('description'); ?>
+                  </div>
+                  <div class="pt-3 text-justify">
+                    <?php if (have_rows('links')) : ?>
+                      <?php while (have_rows('links')) {
+                        the_row(); ?>
+                        <a class="btn btn-lg btn-black" href="<?php the_sub_field('link'); ?>"><?php the_sub_field('label'); ?></a>
+                      <?php } ?>
+                    <?php endif; ?>
                   </div>
                 </div>
               </div>
-              <?php } ?>
             </div>
+          <?php } ?>
         </div>
+      </div>
     <?php endif; ?>
   </div>
 </main>

--- a/web/app/themes/xrnl/structure_circles.php
+++ b/web/app/themes/xrnl/structure_circles.php
@@ -16,7 +16,7 @@ get_header(); ?>
 
     <?php if( have_rows('circles') ): ?>
         <div class="col-lg-12 mb-5 text-justify">
-            <h1 class="font-xr" id="#working-groups"><?php the_field('title') ?></h1>
+            <h1 class="font-xr" id="working-groups"><?php the_field('title') ?></h1>
             <?php the_field('introduction') ?>
             <div class="row">
               <?php while ( have_rows('circles') ){ the_row();

--- a/web/app/themes/xrnl/structure_circles.php
+++ b/web/app/themes/xrnl/structure_circles.php
@@ -20,16 +20,17 @@ get_header(); ?>
             <?php the_field('introduction') ?>
             <div class="row">
               <?php while ( have_rows('circles') ){ the_row();
-              $groupId = "circle-" . formatElementID(get_sub_field('title'));
+            $sectionId = formatElementID(get_sub_field('title'));
+            $sectionTextId = $sectionId . "-text";
             ?>
               <div class="col-12 py-2">
-                <div id="<?php echo formatElementID(get_sub_field('title')); ?>" class="mx-auto">
-                  <a class="btn btn-yellow btn-lg btn-block text-left" data-toggle="collapse" href="#<?php echo $groupId; ?>"
-                    role="button" aria-expanded="false" aria-controls="<?php echo $groupId; ?>">
+                <div id="<?php echo $sectionId; ?>" class="mx-auto">
+                  <a class="btn btn-yellow btn-lg btn-block text-left" data-toggle="collapse" href="#<?php echo $sectionTextId; ?>"
+                    role="button" aria-expanded="false" aria-controls="<?php echo $sectionTextId; ?>">
                     <?php the_sub_field('title') ?>
                     <i class="fas fa-chevron-down float-right pt-1"></i>
                   </a>
-                  <div class="text-left collapse pt-2" id="<?php echo $groupId; ?>">
+                  <div class="text-left collapse pt-2" id="<?php echo $sectionTextId; ?>">
                     <div class="pt-3 text-justify">
                         <?php the_sub_field('description'); ?>
                     </div>


### PR DESCRIPTION
@franei people in the integration circle are planning to add a lot of relevant information to the [how we work](https://extinctionrebellion.nl/aan-de-slag-bij-xr/) page so that people can learn all they need to know to help out as a volunteer in XR.

The problem with that page is that it's one big blog of text that is very hard to navigate. Thats' why they would like to add foldout sections just like in the [structure](https://extinctionrebellion.nl/structuur) page. 

What I've done in this PR is:

#### 1. improve the custom field settings of the structure page

When using these custom fields I noticed that it was very hard to add information to the fold-out sections

![Screenshot from 2021-07-30 13-59-04](https://user-images.githubusercontent.com/15846595/127650296-aa95dc4f-242c-4539-87a6-448f4d5a81c4.png)

Now it's much easier, with more space for the text and a `visual` option to see the rendered html.

![Screenshot from 2021-07-30 13-58-31](https://user-images.githubusercontent.com/15846595/127650325-0709c9c2-c14d-4ac9-8a2c-5390d925eafc.png)

#### 2. copy the custom fields & template of the structure page and make some slight changes

This is how the new page looks like (of course, they will add many more sections):

![image](https://user-images.githubusercontent.com/15846595/127650613-f9fbcd1b-ab84-4be3-86bd-78c62f5f4047.png)



