### PR TITLE
Banner home page

### DIFF
--- a/web/app/themes/xrnl/acf-json/group_5d9678d92c76e.json
+++ b/web/app/themes/xrnl/acf-json/group_5d9678d92c76e.json
@@ -3,6 +3,121 @@
     "title": "Home",
     "fields": [
         {
+            "key": "field_613e806d6898d",
+            "label": "Event highlight section",
+            "name": "event_highlight_section",
+            "type": "group",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "layout": "block",
+            "wpml_cf_preferences": 0,
+            "sub_fields": [
+                {
+                    "key": "field_613e812168992",
+                    "label": "enabled",
+                    "name": "enabled",
+                    "type": "true_false",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "message": "",
+                    "default_value": 0,
+                    "ui": 1,
+                    "ui_on_text": "",
+                    "ui_off_text": "",
+                    "wpml_cf_preferences": 0
+                },
+                {
+                    "key": "field_613e80c16898e",
+                    "label": "title",
+                    "name": "title",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                },
+                {
+                    "key": "field_613e80df6898f",
+                    "label": "date and location",
+                    "name": "date_location",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                },
+                {
+                    "key": "field_613e80f768990",
+                    "label": "link",
+                    "name": "link",
+                    "type": "url",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": "",
+                    "wpml_cf_preferences": 0
+                },
+                {
+                    "key": "field_613e811868991",
+                    "label": "button text",
+                    "name": "button_text",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 0,
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                }
+            ]
+        },
+        {
             "key": "field_5d9679aced134",
             "label": "cover image",
             "name": "cover_image",
@@ -200,5 +315,5 @@
     "hide_on_screen": "",
     "active": true,
     "description": "",
-    "modified": 1621288788
+    "modified": 1631486327
 }

--- a/web/app/themes/xrnl/front-page.php
+++ b/web/app/themes/xrnl/front-page.php
@@ -27,21 +27,28 @@ get_header(); ?>
 
 <div class="home">
 
-  <div class="bg-black text-white" role="button" onclick="location.href='/rebellie';">
-    <div class="border border-10 border-fuchsia p-2">
-      <div class="d-flex flex-column flex-lg-row justify-content-between align-items-center flex-wrap">
-        <h1 class="font-xr text-fuchsia m-0">
-          Join the climate rebellion
-        </h1>
-        <h1 class="font-xr m-0">10-18 October, Den Haag</h1>
-        <div>
-          <a class="btn btn-lg btn-fuchsia text-black" href="/rebellie">join</a>
+  <?php $section = getSection('event_highlight_section'); ?>
+  <?php if ($section->enabled) : ?>
+    <div class="bg-black text-white" role="button" onclick="location.href='<?php echo ($section->link); ?>';">
+      <div class="border border-10 border-fuchsia p-2">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-center flex-wrap">
+          <h1 class="font-xr text-fuchsia m-0">
+            <?php echo ($section->title); ?>
+          </h1>
+          <h1 class="font-xr m-0">
+            <?php echo ($section->date_location); ?>
+          </h1>
+          <div>
+            <button class="btn btn-lg btn-fuchsia text-black">
+              <?php echo ($section->button_text); ?>
+            </button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  <?php endif; ?>
 
-  <div class="text-white cover-image" style="background: linear-gradient(rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.25)), url('<?php the_field('cover_image'); ?>') no-repeat;">
+  <div class="text-white cover-image" style="background: linear-gradient(rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.25)), url('<?php the_field('cover_image'); ?>') no-repeat; background-position: 50%;">
     <div class="container" style="padding: 5rem 2rem">
       <?php the_content(); ?>
     </div>

--- a/web/app/themes/xrnl/front-page.php
+++ b/web/app/themes/xrnl/front-page.php
@@ -26,6 +26,21 @@ $events = new WP_Query($args);
 get_header(); ?>
 
 <div class="home">
+
+  <div class="bg-black text-white" role="button" onclick="location.href='/rebellie';">
+    <div class="border border-10 border-fuchsia p-2">
+      <div class="d-flex flex-column flex-lg-row justify-content-between align-items-center flex-wrap">
+        <h1 class="font-xr text-fuchsia m-0">
+          Join the climate rebellion
+        </h1>
+        <h1 class="font-xr m-0">10-18 October, Den Haag</h1>
+        <div>
+          <a class="btn btn-lg btn-fuchsia text-black" href="/rebellie">join</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div class="masthead bg-blue px-3 py-lg-5 pb-5 text-center text-white cover-image" style="background: linear-gradient(rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0.45)), url('<?php the_field('cover_image'); ?>') no-repeat;">
     <div class="py-5">
       <div class="container">

--- a/web/app/themes/xrnl/front-page.php
+++ b/web/app/themes/xrnl/front-page.php
@@ -41,11 +41,9 @@ get_header(); ?>
     </div>
   </div>
 
-  <div class="masthead bg-blue px-3 py-lg-5 pb-5 text-center text-white cover-image" style="background: linear-gradient(rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0.45)), url('<?php the_field('cover_image'); ?>') no-repeat;">
-    <div class="py-5">
-      <div class="container">
-        <?php the_content(); ?>
-      </div>
+  <div class="text-white cover-image" style="background: linear-gradient(rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.25)), url('<?php the_field('cover_image'); ?>') no-repeat;">
+    <div class="container" style="padding: 5rem 2rem">
+      <?php the_content(); ?>
     </div>
   </div>
 

--- a/web/app/themes/xrnl/front-page.php
+++ b/web/app/themes/xrnl/front-page.php
@@ -29,7 +29,7 @@ get_header(); ?>
 
   <?php $section = getSection('event_highlight_section'); ?>
   <?php if ($section->enabled) : ?>
-    <div class="bg-black text-white" role="button" onclick="location.href='<?php echo ($section->link); ?>';">
+    <div class="bg-black text-white" role="button" onclick="<?= register_button_click('highlighted event'); ?> location.href='<?php echo ($section->link); ?>';">
       <div class="border border-10 border-fuchsia p-2">
         <div class="d-flex flex-column flex-lg-row justify-content-between align-items-center flex-wrap">
           <h1 class="font-xr text-fuchsia m-0">

--- a/web/app/themes/xrnl/front-page.php
+++ b/web/app/themes/xrnl/front-page.php
@@ -4,24 +4,24 @@
 $query_city = array();
 // Events Query
 $args = array(
-	'posts_per_page' => 5,
-	'paged' => 1,
-	'post_type' => 'meetup_events',
-	'orderby' => 'meta_value',
-	'meta_key' => 'event_start_date',
-	'order' => 'ASC',
-	'meta_query' => array(
-		array(
-			'key' => 'event_start_date', // Check the start date field
-			'value' => date("Y-m-d"), // Set today's date (note the similar format)
-			'compare' => '>=', // Return the ones greater than today's date
-			'type' => 'DATE' // Let WordPress know we're working with date
+  'posts_per_page' => 5,
+  'paged' => 1,
+  'post_type' => 'meetup_events',
+  'orderby' => 'meta_value',
+  'meta_key' => 'event_start_date',
+  'order' => 'ASC',
+  'meta_query' => array(
+    array(
+      'key' => 'event_start_date', // Check the start date field
+      'value' => date("Y-m-d"), // Set today's date (note the similar format)
+      'compare' => '>=', // Return the ones greater than today's date
+      'type' => 'DATE' // Let WordPress know we're working with date
     ),
     // adds city filter
     $query_city
-	)
+  )
 );
-$events = new WP_Query( $args );
+$events = new WP_Query($args);
 
 get_header(); ?>
 
@@ -55,32 +55,32 @@ get_header(); ?>
   </div>
 
   <div class="text-center">
-		<?php
-			$image = get_field('image');
-			$image_mobile = get_field('image_mobile');
-		 ?>
-	 <img class="image-desktop img-fluid my-2" src="<?php echo esc_url($image['url']); ?>" alt="<?php echo esc_attr($image['alt']); ?>">
-	 <img class="image-mobile my-2" src="<?php echo esc_url($image_mobile['url']); ?>" alt="<?php echo esc_attr($image_mobile['alt']); ?>">
+    <?php
+    $image = get_field('image');
+    $image_mobile = get_field('image_mobile');
+    ?>
+    <img class="image-desktop img-fluid my-2" src="<?php echo esc_url($image['url']); ?>" alt="<?php echo esc_attr($image['alt']); ?>">
+    <img class="image-mobile my-2" src="<?php echo esc_url($image_mobile['url']); ?>" alt="<?php echo esc_attr($image_mobile['alt']); ?>">
   </div>
 
-  <?php if ( $events->have_posts() ) : ?>
+  <?php if ($events->have_posts()) : ?>
     <div class="py-sm-5 py-4 bg-yellow">
       <div class="container my-5">
         <h1 class="text-center"><?php _e('EVENTS') ?></h1>
-        <?php while ( $events->have_posts() ) : $events->the_post(); ?>
+        <?php while ($events->have_posts()) : $events->the_post(); ?>
           <div class="row border-bottom border-black pt-3 pb-3">
             <?php
-              $event_date = get_post_meta( get_the_ID(), 'event_start_date', true );
-              if( $event_date != '' ){
-                $event_date = strtotime( $event_date );
-              }
-              $event_address = get_post_meta( get_the_ID(), 'venue_city', true );
-              $venue_address = get_post_meta( get_the_ID(), 'venue_address', true );
+            $event_date = get_post_meta(get_the_ID(), 'event_start_date', true);
+            if ($event_date != '') {
+              $event_date = strtotime($event_date);
+            }
+            $event_address = get_post_meta(get_the_ID(), 'venue_city', true);
+            $venue_address = get_post_meta(get_the_ID(), 'venue_address', true);
             ?>
             <div class="col-lg-2 col-sm-12">
               <div class="text-uppercase font-xr small pt-1">
-                <?php echo date_i18n('M', $event_date) ; ?>
-                <?php echo date_i18n('d', $event_date) ; ?>
+                <?php echo date_i18n('M', $event_date); ?>
+                <?php echo date_i18n('d', $event_date); ?>
               </div>
               <small>
                 <strong><em><?php echo $event_address; ?></em></strong>
@@ -89,13 +89,13 @@ get_header(); ?>
               </small>
             </div>
             <div class="col-lg-8 col-sm-12">
-              <a href="<?php echo esc_url( get_permalink() ) ?>" class="text-reset text-uppercase font-xr text-decoration-none small">
+              <a href="<?php echo esc_url(get_permalink()) ?>" class="text-reset text-uppercase font-xr text-decoration-none small">
                 <?php the_title(); ?>
               </a>
               <div class="small pt-2"><em><?php echo excerpt(30); ?></em></div>
             </div>
             <div class="col-lg-2 col-sm-12 text-lg-right">
-              <a class="btn btn-black" href="<?php echo esc_url( get_permalink() ) ?>">
+              <a class="btn btn-black" href="<?php echo esc_url(get_permalink()) ?>">
                 <?php _e('VIEW') ?>
               </a>
             </div>
@@ -104,8 +104,7 @@ get_header(); ?>
         <?php wp_reset_query(); ?>
         <br>
         <div class="text-center">
-          <a class="btn btn-lg btn-black" href="/events" 
-onclick="<?= register_button_click('view all events') ?>">
+          <a class="btn btn-lg btn-black" href="/events" onclick="<?= register_button_click('view all events') ?>">
             <?php _e('VIEW ALL EVENTS') ?>
           </a>
         </div>


### PR DESCRIPTION
@franei the rebellion coordinators wanted to have the banner for the rebellion on the website before they send out the next newsletter on Monday (in less than 12 hours). This week I've had to postpone and postpone, and I've ended up doing this now in a couple of hours. Because they want it so urgently I'll again merge & deploy straight away :roll_eyes: but I would still value your feedback when you have some time :pray:  

I've made 2 main improvements to the home page:

1. the banner for a highlighted event (in this case the rebellion event)
2. improvements to the hero section

### 1. banner

Here is how it looks on desktop and on mobile

![image](https://user-images.githubusercontent.com/15846595/133005489-86e6be51-2331-4ac4-ba26-485c2dab9d8a.png)

![image](https://user-images.githubusercontent.com/15846595/133005503-6ca4dfe6-71cc-4112-8afe-5ba238934680.png)

A few things to note about this banner:

1. you can change the text & link from Wordpress, but not the colours at the moment
2. the whole banner is clickable (I chose this option because the button is very hidden to the side on desktop)
3. it's not complete: some things to improve are adding the countdown and maybe also an hourglass icon

### 2. cover

When updating the cover to match the new design that Kaj proposed I found two issues, which I fixed.

The first issue is that the overlay was too dark, and therefore it made the image stand out less. I slightly decreased the opacity of this overlay. Here are some before and after pictures. Here is a picture of both side by side (with the right one being the new one, with a less strong overlay). I'm not sure if this is right, maybe we can make the overlay even lighter, or maybe we need to make it again darker for accessibility.

![Screenshot from 2021-09-13 01-11-29](https://user-images.githubusercontent.com/15846595/133005685-7bf084dc-bc1f-44ae-a8d4-c258887989d2.png)

Secondly, I made the cover image nice and centred. I did that by adding `background-position: 50%;` (hidden all the way at the bottom of [this commit](https://github.com/xrnl/extinction-rebellion-nl/commit/b43f0c7d060caa9c42a05a5a6a41ae481d1e9dff))

Here are some before and after pictures:

![Screenshot from 2021-09-13 00-26-41](https://user-images.githubusercontent.com/15846595/133005764-c191c3f1-e5d3-46cb-bece-93ec1570b688.png)

![Screenshot from 2021-09-13 00-28-10](https://user-images.githubusercontent.com/15846595/133005836-a046d7ab-79ec-493f-adfc-b4a093a52e33.png)


Also on mobile the image is now centred (instead of zooming on the left side)

![Screenshot from 2021-09-13 00-27-05](https://user-images.githubusercontent.com/15846595/133005762-6118481f-eab1-45c4-9be6-e46a9b26c429.png)


![Screenshot from 2021-09-13 00-28-02](https://user-images.githubusercontent.com/15846595/133005811-605e118f-40f5-46f3-9c1f-af5377c096af.png)


