### PR TITLE
Add missing dependencies for generating the theme

### DIFF
--- a/web/app/themes/xrnl/package.json
+++ b/web/app/themes/xrnl/package.json
@@ -10,14 +10,20 @@
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
+        "babel-loader": "^8.2.2",
         "bootstrap": "4.6.0",
         "cross-env": "^5.1",
+        "css-loader": "^1.0.1",
         "jquery": "^3.2",
         "laravel-mix": "^4.0.7",
         "lodash": "^4.17.5",
         "popper.js": "^1.12",
+        "postcss-loader": "^3.0.0",
         "resolve-url-loader": "^2.3.1",
         "sass": "^1.15.2",
-        "sass-loader": "^7.1.0"
+        "sass-loader": "^7.1.0",
+        "style-loader": "^0.23.1",
+        "vue-template-compiler": "^2.6.14",
+        "webpack": "^4.46.0"
     }
 }


### PR DESCRIPTION
This has not been an issue so far because npm throws transitive dependencies in the same node_modules as direct dependencies.
All these dependencies were also dependencies of `laravel-mix` so they were present, but we depend on them directly so they should be added.
