### PR TITLE
Demand 0

### DIFF
--- a/web/app/themes/xrnl/about.php
+++ b/web/app/themes/xrnl/about.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Template name: About
  */
@@ -21,25 +22,9 @@ get_header(); ?>
           <?php the_field('why_description'); ?>
         </div>
       </div>
-      <div class="row">
-        <div class="col-12 col-lg-6 mx-auto mt-3">
-          <a class="btn btn-yellow btn-lg" data-toggle="collapse" href="#demands" role="button" aria-expanded="false" aria-controls="demands" 
-onclick="<?= register_button_click('our demands') ?>">
-            <?php _e('OUR DEMANDS', 'theme-xrnl'); ?>
-            <i class="fas fa-chevron-down"></i>
-          </a>
-          <div class="text-left collapse" id="demands">
-            <?php get_template_part('template-parts/demands-list'); ?>
-          </div>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-12 text-center pt-5">
-          <img src="<?php the_field('logo'); ?>" style="width: 100px;"/>
-        </div>
-      </div>
     </div>
   </div>
+  <?php get_template_part('template-parts/demands-list'); ?>
 
   <div class="text-center mt-sm-5 mt-4">
     <div class="container pt-5">
@@ -61,11 +46,11 @@ onclick="<?= register_button_click('our demands') ?>">
       <h1><?php the_field('organisation_title'); ?></h1>
       <p><?php the_field('organisation_description'); ?></p>
 
-      <?php while ( have_rows('organisation_topics') ){ the_row(); ?>
+      <?php while (have_rows('organisation_topics')) {
+        the_row(); ?>
         <div class="row py-2">
           <div id="<?php echo formatElementID(get_sub_field('topic_tilte')); ?>" class="col-12 col-lg-6 mx-auto">
-            <a class="btn btn-yellow btn-lg btn-block text-left" data-toggle="collapse" href="#topic-<?php echo get_row_index(); ?>" role="button" aria-expanded="false" aria-controls="topic-<?php echo get_row_index(); ?>" 
-onclick="<?= register_button_click(get_sub_field('topic_tilte')) ?>">
+            <a class="btn btn-yellow btn-lg btn-block text-left" data-toggle="collapse" href="#topic-<?php echo get_row_index(); ?>" role="button" aria-expanded="false" aria-controls="topic-<?php echo get_row_index(); ?>" onclick="<?= register_button_click(get_sub_field('topic_tilte')) ?>">
               <?php the_sub_field('topic_tilte') ?>
               <i class="fas fa-chevron-down float-right pt-1"></i>
             </a>

--- a/web/app/themes/xrnl/acf-json/group_5fa311a77eb3b.json
+++ b/web/app/themes/xrnl/acf-json/group_5fa311a77eb3b.json
@@ -3,6 +3,124 @@
     "title": "Demands",
     "fields": [
         {
+            "key": "field_5fa3f85802159",
+            "label": "Demands title",
+            "name": "xrnl_demands_title",
+            "type": "text",
+            "instructions": "",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_61557a6cdb5da",
+            "label": "Demands pre-title",
+            "name": "xrnl_demands_pre_title",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_615578e0db5d7",
+            "label": "Demand 0",
+            "name": "xrnl_demand_0",
+            "type": "group",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "wpml_cf_preferences": 0,
+            "layout": "block",
+            "sub_fields": [
+                {
+                    "key": "field_61557bf197cab",
+                    "label": "enabled",
+                    "name": "enabled",
+                    "type": "true_false",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "message": "",
+                    "default_value": 1,
+                    "ui": 0,
+                    "wpml_cf_preferences": 0,
+                    "ui_on_text": "",
+                    "ui_off_text": ""
+                },
+                {
+                    "key": "field_615578e0db5d8",
+                    "label": "Bold text",
+                    "name": "bold_text",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "wpml_cf_preferences": 2,
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                },
+                {
+                    "key": "field_615578e0db5d9",
+                    "label": "Regular text",
+                    "name": "regular_text",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": "",
+                    "wpml_cf_preferences": 0
+                }
+            ]
+        },
+        {
             "key": "field_5fa31249ed2fd",
             "label": "Demands list",
             "name": "xrnl_demands_list",
@@ -15,7 +133,7 @@
                 "class": "",
                 "id": ""
             },
-            "wpml_cf_preferences": 0,
+            "wpml_cf_preferences": 1,
             "collapsed": "",
             "min": 0,
             "max": 0,
@@ -71,42 +189,22 @@
                                 "class": "",
                                 "id": ""
                             },
-                            "wpml_cf_preferences": 2,
                             "default_value": "",
                             "placeholder": "",
                             "prepend": "",
                             "append": "",
-                            "maxlength": ""
+                            "maxlength": "",
+                            "wpml_cf_preferences": 0
                         }
                     ]
                 }
             ]
         },
         {
-            "key": "field_5fa3f85802159",
-            "label": "Text above demands",
-            "name": "xrnl_demands_txt_above",
-            "type": "text",
-            "instructions": "",
-            "required": 0,
-            "conditional_logic": 0,
-            "wrapper": {
-                "width": "",
-                "class": "",
-                "id": ""
-            },
-            "wpml_cf_preferences": 0,
-            "default_value": "",
-            "placeholder": "",
-            "prepend": "",
-            "append": "",
-            "maxlength": ""
-        },
-        {
             "key": "field_5fa44251ca525",
             "label": "Text below demands",
             "name": "xrnl_demands_txt_below",
-            "type": "text",
+            "type": "wysiwyg",
             "instructions": "",
             "required": 0,
             "conditional_logic": 0,
@@ -117,10 +215,10 @@
             },
             "wpml_cf_preferences": 0,
             "default_value": "",
-            "placeholder": "",
-            "prepend": "",
-            "append": "",
-            "maxlength": ""
+            "tabs": "all",
+            "toolbar": "basic",
+            "media_upload": 0,
+            "delay": 0
         },
         {
             "key": "field_5fa442870ed41",
@@ -180,7 +278,7 @@
     "label_placement": "top",
     "instruction_placement": "label",
     "hide_on_screen": "",
-    "active": 1,
+    "active": true,
     "description": "",
-    "modified": 1604603323
+    "modified": 1632994124
 }

--- a/web/app/themes/xrnl/assets/sass/_variables.scss
+++ b/web/app/themes/xrnl/assets/sass/_variables.scss
@@ -15,6 +15,9 @@ $xr-angry: #c80082;
 $xr-primary: $xr-green;
 $xr-light-gray: lighten($xr-black, 85%);
 $xr-nl-fuchsia: #e71a84; // color used for climate rebellion 2021
+// colours used for climate justice (cj) related content
+$cj-dark-gray: #181a1b;
+$cj-light-gray: #c9c4bd;
 
 $theme-colors: (
   "primary": $xr-primary,
@@ -33,6 +36,8 @@ $theme-colors: (
   "bright-pink": $xr-bright-pink,
   "light-gray": $xr-light-gray,
   "fuchsia": $xr-nl-fuchsia,
+  "cj-dark-gray": $cj-dark-gray,
+  "cj-light-gray": $cj-light-gray,
 ) !default;
 
 $navbar-light-toggler-border-color: rgba(0, 0, 0, 0);

--- a/web/app/themes/xrnl/assets/sass/custom.scss
+++ b/web/app/themes/xrnl/assets/sass/custom.scss
@@ -312,3 +312,18 @@ a.btn-black-r-invert:hover {
     }
   }
 }
+
+.page-section {
+  padding-top: 6rem;
+  padding-bottom: 6rem;
+  padding-left: 4rem;
+  padding-right: 4rem;
+
+  @include media-breakpoint-down(md) {
+    padding: 1.5rem;
+  }
+  @include media-breakpoint-down(xs) {
+    padding: 1rem;
+  }
+}
+

--- a/web/app/themes/xrnl/assets/sass/typography.scss
+++ b/web/app/themes/xrnl/assets/sass/typography.scss
@@ -83,3 +83,19 @@ main {
     @extend .text-fuchsia;
   }
 }
+
+
+.section-title {
+  @extend .font-xr;
+  line-height: 1;
+  font-size: 5rem;
+  @include media-breakpoint-down(md) {
+    font-size: 3rem;
+  }
+}
+
+.section-pre-title {
+  @extend .font-xr;
+  font-size: 1.125rem;
+  margin-bottom: .25rem;
+}

--- a/web/app/themes/xrnl/header.php
+++ b/web/app/themes/xrnl/header.php
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charSet="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -9,7 +10,7 @@
 
   <link href="https://fonts.googleapis.com/css?family=Crimson+Text|Montserrat" rel="stylesheet" />
   <link rel="stylesheet" href="<?php echo get_theme_file_uri("dist/fonts/fucxed.css"); ?>" />
-  <link rel="stylesheet" href="<?php echo get_theme_file_uri("dist/css/app.css".date("?Ymd")."?v2"); ?>" />
+  <link rel="stylesheet" href="<?php echo get_theme_file_uri("dist/css/app.css" . date("?Ymd") . "?v1"); ?>" />
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous" />
   <!-- Matomo -->
   <script type="text/javascript">
@@ -19,11 +20,16 @@
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
     (function() {
-      var u="//extinctionrebellion.nl/matomo/";
-      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      var u = "//extinctionrebellion.nl/matomo/";
+      _paq.push(['setTrackerUrl', u + 'matomo.php']);
       _paq.push(['setSiteId', '1']);
-      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-      g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+      var d = document,
+        g = d.createElement('script'),
+        s = d.getElementsByTagName('script')[0];
+      g.type = 'text/javascript';
+      g.async = true;
+      g.src = u + 'matomo.js';
+      s.parentNode.insertBefore(g, s);
     })();
   </script>
   <!-- End Matomo Code -->
@@ -31,75 +37,75 @@
 </head>
 
 <?php
-  $args = wp_parse_args($args, array(
-    'bg-color'      => 'green', // optional bg-color, defaults to green
-    'accent-color'  => 'white', // optional highlight color, defaults to white
-    'navbar-logo'   => 'xrnl-hoogwater-symbol.svg' // takes optional svg file from /dist/images
-  ));
+$args = wp_parse_args($args, array(
+  'bg-color'      => 'green', // optional bg-color, defaults to green
+  'accent-color'  => 'white', // optional highlight color, defaults to white
+  'navbar-logo'   => 'xrnl-hoogwater-symbol.svg' // takes optional svg file from /dist/images
+));
 ?>
 
 <body>
   <header class="bg-xr-<?php echo $args['bg-color'] ?>">
     <nav class="navbar navbar-light navbar-expand-xl nav-accent-xr-<?php echo $args['accent-color']; ?>" role="navigation">
 
-      <a class="navbar-brand" href="<?php echo (ICL_LANGUAGE_CODE === 'nl') ? '/' : '/en'; ?>" onclick="<?= register_button_click('logo', 'header')?>">
+      <a class="navbar-brand" href="<?php echo (ICL_LANGUAGE_CODE === 'nl') ? '/' : '/en'; ?>" onclick="<?= register_button_click('logo', 'header') ?>">
         <img src="<?php echo get_theme_file_uri('/dist/images/' . $args['navbar-logo']); ?>" alt="Extinction Rebellion Nederland">
       </a>
 
       <div>
         <?php
-          $donatePage = apply_filters('wpml_object_id', 308, 'page', true); // 308 is page ID
-          $donatePageURL = get_permalink( $donatePage );
+        $donatePage = apply_filters('wpml_object_id', 308, 'page', true); // 308 is page ID
+        $donatePageURL = get_permalink($donatePage);
 
-          $joinPage = apply_filters('wpml_object_id', 7587, 'page', true); // 7587 is page ID
-          $joinPageUrl = get_permalink( $joinPage );
+        $joinPage = apply_filters('wpml_object_id', 7587, 'page', true); // 7587 is page ID
+        $joinPageUrl = get_permalink($joinPage);
         ?>
         <a href="<?php echo $donatePageURL ?>" class="btn btn-black-r-invert hide-xl" target="_blank" onclick="<?= register_button_click('donate (mobile)', 'header'); ?>"><?php _e('donate', 'theme-xrnl'); ?></a>
         <a href="<?php echo $joinPageUrl ?>" class="btn btn-black-r hide-xl" onclick="<?= register_button_click('join us (mobile)', 'header'); ?>"><?php _e('join us', 'theme-xrnl'); ?></a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main-nav" aria-controls="main-nav" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
+          <span class="navbar-toggler-icon"></span>
         </button>
       </div>
 
       <div class="collapse navbar-collapse" id="main-nav">
-        <?php wp_nav_menu( [
-            'theme_location'         => 'primary',
-            'depth'	                 => 2,
-            'container'              => '',
-            'menu_class'             => 'navbar-nav',
-            'clicks_page_identifier' => 'header',
-            'fallback_cb'            => 'WP_Bootstrap_Navwalker::fallback',
-            'walker'                 => new WP_Bootstrap_Navwalker(),
-          ]); 
+        <?php wp_nav_menu([
+          'theme_location'         => 'primary',
+          'depth'                   => 2,
+          'container'              => '',
+          'menu_class'             => 'navbar-nav',
+          'clicks_page_identifier' => 'header',
+          'fallback_cb'            => 'WP_Bootstrap_Navwalker::fallback',
+          'walker'                 => new WP_Bootstrap_Navwalker(),
+        ]);
         ?>
 
         <ul class="list-unstyled d-flex my-3 my-xl-0 align-items-center ml-auto">
           <li class="mx-3 mx-lg-2 show-xl">
-            <?php wp_nav_menu( [
-                'theme_location' => 'language',
-                'container'       => '',
-                'fallback_cb'     => 'WP_Bootstrap_Navwalker::fallback',
-                'menu_class'      => 'navbar-nav language-menu',
-                'walker'          => new WP_Bootstrap_Navwalker(),
-            ] ); ?>
+            <?php wp_nav_menu([
+              'theme_location' => 'language',
+              'container'       => '',
+              'fallback_cb'     => 'WP_Bootstrap_Navwalker::fallback',
+              'menu_class'      => 'navbar-nav language-menu',
+              'walker'          => new WP_Bootstrap_Navwalker(),
+            ]); ?>
           </li>
           <li class="mx-3 mx-lg-2 show-xl">
             <a href="<?php echo $donatePageURL ?>" class="btn btn-black-r-invert" target="_blank" onclick="<?= register_button_click('donate (desktop)', 'header'); ?>"><?php _e('donate', 'theme-xrnl'); ?></a>
           </li>
           <li class="mx-3 mx-lg-2 hide-xl show-xl">
-            <a href="<?php echo $joinPageUrl ?>" class="btn btn-black-r" onclick="<?= register_button_click('join us (desktop)', 'header'); ?>"><?php _e('join us', 'theme-xrnl'); ?></a>            
+            <a href="<?php echo $joinPageUrl ?>" class="btn btn-black-r" onclick="<?= register_button_click('join us (desktop)', 'header'); ?>"><?php _e('join us', 'theme-xrnl'); ?></a>
           </li>
         </ul>
 
         <div class="d-flex">
           <div class="hide-xl">
-            <?php wp_nav_menu( [
-                'theme_location' => 'language',
-                'container'       => '',
-                'fallback_cb'     => 'WP_Bootstrap_Navwalker::fallback',
-                'menu_class'      => 'navbar-nav language-menu',
-                'walker'          => new WP_Bootstrap_Navwalker(),
-            ] ); ?>
+            <?php wp_nav_menu([
+              'theme_location' => 'language',
+              'container'       => '',
+              'fallback_cb'     => 'WP_Bootstrap_Navwalker::fallback',
+              'menu_class'      => 'navbar-nav language-menu',
+              'walker'          => new WP_Bootstrap_Navwalker(),
+            ]); ?>
           </div>
         </div>
       </div>

--- a/web/app/themes/xrnl/petition.php
+++ b/web/app/themes/xrnl/petition.php
@@ -128,21 +128,11 @@ get_header(); ?>
                 <div class="col-12 col-sm-10 col-md-8 col-lg-6 col-xl-6 mx-auto px-4">
                     <h2><?php echo($section->heading); ?></h2>
                     <?php echo($section->content); ?>
-              <?php if($section->demands): ?>
-                  <a class="btn btn-black btn-lg mt-3" data-toggle="collapse" href="#demands" role="button" aria-expanded="false" aria-controls="demands">
-                    <?php _e('OUR DEMANDS', 'theme-xrnl'); ?>
-                    <i class="fas fa-chevron-down"></i>
-                  </a>
-                  <div class="text-left collapse" id="demands">
-                    <?php get_template_part('template-parts/demands-list'); ?>
-                  </div>
-                </div>
-              <?php endif; ?>
-
             </div>
         </section>
     <?php endif; ?>
 
+    <?php get_template_part('template-parts/demands-list'); ?>
     <?php $section = getSection('who_is_extinction_rebellion_section');
     ?>
     <?php if ($section->enabled) : ?>

--- a/web/app/themes/xrnl/template-parts/demands-list.php
+++ b/web/app/themes/xrnl/template-parts/demands-list.php
@@ -1,43 +1,49 @@
 <?php
+
 /**
  * The template part for displaying the list of demands
  */
 ?>
 
-  <div class="demands-list">
+<div class="page-section bg-cj-dark-gray text-white">
+  <h4 class="section-pre-title">
+    Dit is wat wij eisen van de Nederlandse Overheid
+  </h4>
+  <h1 class="section-title">
+    Onze eisen
+  </h1>
 
-    <?php if (get_field('xrnl_demands_txt_above', 'option')) : ?>
-      <div class="mt-4">
-        <?php the_field('xrnl_demands_txt_above', 'option'); ?>
-      </div>
-    <?php endif; ?>
-
-    <?php if( have_rows('xrnl_demands_list', 'option') ): ?>
-      <ol class="pl-3 counter mt-3">
-        <?php while( have_rows('xrnl_demands_list', 'option') ): the_row(); ?>
-          <?php $demand = get_sub_field('demand'); ?>
-            <li class="pl-4">
-              <span class="text-green font-xr">
-                <?php echo $demand['bold_text']; ?>
-              </span>
-              <span>
-                <?php echo $demand['regular_text']; ?>
-              </span>
-            </li>
-        <?php endwhile; ?>
-      </ol>
-    <?php endif; ?>
-
-    <?php if (get_field('xrnl_demands_txt_below', 'option')) : ?>
-      <div class="mt-4">
-        <?php the_field('xrnl_demands_txt_below', 'option'); ?>
-      </div>
-    <?php endif; ?>
-
-    <?php if (get_field('xrnl_demands_link_target', 'option')) : ?>
-      <div class="pt-3 text-center">
-        <a href="<?php the_field('xrnl_demands_link_target', 'option'); ?>"><?php the_field('xrnl_demands_link_label', 'option'); ?></a>
-      </div>
-    <?php endif; ?>
-
+  <div class="p-3 text-cj-light-gray">
+    <span class="font-xr">
+      0. KLIMAATRECHTVAARDIGHEID VOOR IEDEREEN*:
+    </span>
+    <span>
+      We eisen een rechtvaardige transitie die de behoeften en stemmen van
+      degenen die het meest getroffen worden door de klimaatcrisis centraal stelt
+      en degenen die het meest verantwoordelijk zijn voor ecologische verwoesting
+      ter verantwoording roept.
+    </span>
   </div>
+
+  <div class="d-flex flex-column flex-md-row">
+    <?php if (have_rows('xrnl_demands_list', 'option')) : ?>
+      <?php while (have_rows('xrnl_demands_list', 'option')) : the_row(); ?>
+        <?php $demand = get_sub_field('demand'); ?>
+        <div class="bg-white text-black p-3 my-2 my-md-0 mx-0 mx-md-2">
+          <span class="text-green font-xr">
+            <?php echo $demand['bold_text']; ?>
+          </span>
+          <span>
+            <?php echo $demand['regular_text']; ?>
+          </span>
+        </div>
+      <?php endwhile; ?>
+    <?php endif; ?>
+  </div>
+
+  <?php if (get_field('xrnl_demands_txt_below', 'option')) : ?>
+    <div class="pt-3 px-3 text-cj-light-gray" style="font-size: 1.2rem;">
+      <?php the_field('xrnl_demands_txt_below', 'option'); ?>
+    </div>
+  <?php endif; ?>
+</div>

--- a/web/app/themes/xrnl/template-parts/demands-list.php
+++ b/web/app/themes/xrnl/template-parts/demands-list.php
@@ -46,7 +46,7 @@
   </div>
 
   <?php if (get_field('xrnl_demands_txt_below', 'option')) : ?>
-    <div class="pt-3 px-3">
+    <div class="pt-3 px-3 text-cj-light-gray" style="font-size: 1.2rem;">
       <?php the_field('xrnl_demands_txt_below', 'option'); ?>
     </div>
   <?php endif; ?>

--- a/web/app/themes/xrnl/template-parts/demands-list.php
+++ b/web/app/themes/xrnl/template-parts/demands-list.php
@@ -6,24 +6,28 @@
 ?>
 
 <div class="page-section bg-cj-dark-gray text-white">
-  <h4 class="section-pre-title">
-    Dit is wat wij eisen van de Nederlandse Overheid
-  </h4>
+  <?php if (get_field('xrnl_demands_pre_title', 'option')) : ?>
+    <h4 class="section-pre-title">
+      <?php the_field('xrnl_demands_pre_title', 'option'); ?>
+    </h4>
+  <?php endif; ?>
   <h1 class="section-title">
-    Onze eisen
+    <?php the_field('xrnl_demands_title', 'option'); ?>
   </h1>
 
-  <div class="p-3 text-cj-light-gray">
-    <span class="font-xr">
-      0. KLIMAATRECHTVAARDIGHEID VOOR IEDEREEN*:
-    </span>
-    <span>
-      We eisen een rechtvaardige transitie die de behoeften en stemmen van
-      degenen die het meest getroffen worden door de klimaatcrisis centraal stelt
-      en degenen die het meest verantwoordelijk zijn voor ecologische verwoesting
-      ter verantwoording roept.
-    </span>
-  </div>
+
+  <?php $demand_0 = (object) get_field('xrnl_demand_0', 'option');
+  if ($demand_0->enabled) :
+  ?>
+    <div class="p-3 text-cj-light-gray">
+      <span class="font-xr">
+        <?php echo $demand_0->bold_text; ?>
+      </span>
+      <span>
+        <?php echo $demand_0->regular_text; ?>
+      </span>
+    </div>
+  <?php endif; ?>
 
   <div class="d-flex flex-column flex-md-row">
     <?php if (have_rows('xrnl_demands_list', 'option')) : ?>
@@ -42,8 +46,18 @@
   </div>
 
   <?php if (get_field('xrnl_demands_txt_below', 'option')) : ?>
-    <div class="pt-3 px-3 text-cj-light-gray" style="font-size: 1.2rem;">
+    <div class="pt-3 px-3">
       <?php the_field('xrnl_demands_txt_below', 'option'); ?>
     </div>
   <?php endif; ?>
+
+  <?php if (get_field('xrnl_demands_link_target', 'option')) : ?>
+    <div class="pt-3 text-center">
+      <a class="btn btn-green" href="<?php the_field('xrnl_demands_link_target', 'option'); ?>">
+        <?php the_field('xrnl_demands_link_label', 'option'); ?>
+      </a>
+    </div>
+  <?php endif; ?>
+
+
 </div>

--- a/web/app/themes/xrnl/why-rebel.php
+++ b/web/app/themes/xrnl/why-rebel.php
@@ -77,21 +77,6 @@ get_header(); ?>
     </div>
   </section>
 
-  <?php $labels = getSection('demands'); ?>
-  <section id="demands" class="container-fluid">
-    <div class="row">
-      <div class="content col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">
-        <div id="demands-btn">
-          <span id="reveal-demands-btn" class="demands-toggle reveal-demands"><?php echo $labels->show_demands_text ?></span>
-          <span id="hide-demands-btn" class="demands-toggle hide-demands" style="display: none;"><?php echo $labels->hide_demands_text ?></span>
-        </div>
-        <div id="demands-list" style="display: none;">
-          <?php get_template_part('template-parts/demands-list'); ?>
-        </div>
-      </div>
-    </div>
-  </section>
-
   <section id="why-rebel" class="text-section container-fluid">
     <div class="row">
       <div class="content col-12 col-sm-10 col-md-8 col-lg-8 col-xl-7 mx-auto">


### PR DESCRIPTION
New design for the list of demands, including the new demand 0. I'll first list the design decisions I made and which you might want to comment on. At the bottom you can find screenshots for how it looks on Desktop and on mobile. To review the changes it's easiest to review each of the commits one by one.

#### Design decisions

- make background colour the colour of the climate justice demand & make a distinct colour for our main 3 demands. I hope that this illustrates that demand 0 is the base for our 3 demands.
- display demands side by side on Desktop (instead of on top of each other like before). I like this from the XR global website as it saves some nice vertical space and makes full use of the screen width. Also this allows people to make a screenshot of the website and use this in the slides for talks / trainings etc.
- always display the demands on the about page, instead of showing them if user clicks on "our demands". I think it's important to always show the demands because it shows what we are working towards (regardless of what the media or people say about us). Also this makes the design much nicer because now the demands can occupy the full width of the page.
- I removed the demands from the emergency page because it didn't work with the new design and I don't think it's necessary to also have it on that page.
- I added a big title and a small pre-title (above the title), with exactly the responsive styles of the global page. I hope we can reuse this for other new sections.

#### Screenshots


![image](https://user-images.githubusercontent.com/15846595/135453101-d3e831d4-47d6-4d26-aa10-6940ed5058d6.png)


![Screenshot 2021-09-30 at 13-02-30 Over ons · Extinction Rebellion Nederland](https://user-images.githubusercontent.com/15846595/135444260-41acf9a4-2edb-451c-8dfd-6bb693e7898c.jpg)

(edit) I see that in this second screenshot I forgot to adjust the colour of the link at the end. This will be ok once we deploy it and I add the content through wordpress.